### PR TITLE
chore(repo): finish phase 1 cleanup, drop stale sub-project footnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,6 @@ npm start demo api-quick     # REST API with tests and Dockerfile, ~5 min
 - **Agent subprocess hangs** — ensure the agent CLI (`copilot`, `claude-code`, or `codex`) is installed, authenticated, and responds to `--help`. The orchestrator invokes it as a child process.
 - **Docker Compose fails to start** — verify Docker is running and port 5432 (PostgreSQL) is free. Use `docker compose logs <service>` to diagnose.
 - **Python tests fail with import errors** — install Python dependencies: `pip install fastapi pydantic sqlalchemy uvicorn httpx pytest` or use the `.venv` if present.
-- **Sub-project tests fail with `ERR_MODULE_NOT_FOUND`** — run `npm install` inside the sub-project directory (`calculations-api/`, `notes-api/`) before running tests. Sub-projects that use only Node.js built-ins (`calculator/`, `logtail/`, `tictactoe/`) need no install step.
 
 <br>
 

--- a/phase1-verification.txt
+++ b/phase1-verification.txt
@@ -1,0 +1,89 @@
+# Phase 1 Verification
+# Branch: cleanup/repo-pollution
+# Date: 2026-04-21T14:07:36Z
+# Host: Linux 6.17.0-20-generic x86_64
+# Node: v24.12.0
+# npm:  11.6.2
+
+## Background
+Bulk file removals (.venv, runs/, src/health_service.egg-info/, demo subproject dirs,
+RELEASE-*.md, .codex, SECURITY-AUDIT.md) landed earlier in commit 76e5ce6.
+Release notes were relocated to docs/releases/ rather than GitHub Release bodies;
+GitHub releases for v4.1.0 / v4.2.0 / v5.0.0 already exist per user confirmation.
+This branch finishes: stale README sub-project footnote removal + verification capture.
+
+## git ls-files total
+510
+
+## git ls-files .venv/
+0
+
+## git ls-files runs/
+0
+
+## git ls-files src/health_service.egg-info/
+0
+
+## git ls-files app/ tictactoe/ web/ calculator/ calculations-api/ logtail/ notes-api/
+0
+
+## SECURITY-AUDIT.md absence
+removed
+
+## .codex absence
+removed
+
+## RELEASE*.md at repo root
+0
+
+## .gitignore IMPROVEMENTS.md occurrences
+1
+
+## package.json engines.node
+>=20.0.0
+
+## README node version mentions (first 3)
+![Node.js 20+](https://img.shields.io/badge/node-20%2B-green.svg)
+Requires Node.js 20+, Git, and at least one supported agent CLI:
+| GitHub Copilot CLI | `npm install -g @github/copilot` | Launch `copilot` and run `/login` (requires Node.js 22+) |
+
+## `: any` in src/
+0
+
+## package.json scripts (verify deleted demo scripts gone)
+build
+build-plugin
+clean
+prebuild
+prepublishOnly
+test
+test:ci
+lint
+lint:fix
+typecheck
+format
+format:check
+start
+docker:build
+docker:run
+docker:up
+docker:down
+docker:dev
+deploy
+
+## Deleted scripts check
+  docker:build:health: removed
+  docker:build:calc: removed
+  docker:build:notes: removed
+  docker:build:web: removed
+  docker:build:all: removed
+  test:python: removed
+  test:subprojects: removed
+  test:all: removed
+
+## npm test result (tail)
+
+
+  1420 passing (30s)
+  6 pending
+


### PR DESCRIPTION
## Summary
- First PR for the v6.0 build. The bulk pollution removal (.venv, runs/, egg-info, demo subproject dirs, RELEASE*.md, .codex, SECURITY-AUDIT.md) already landed in 76e5ce6; prior commits also reconciled engines.node, removed demo docker/test scripts, deduped IMPROVEMENTS.md in .gitignore, and cleared `any` from `src/gate-remediation.ts`.
- Remaining item: dropped a stale README common-issues bullet that referenced removed sub-projects (calculator/logtail/tictactoe/calculations-api/notes-api).
- Captured `phase1-verification.txt` with every check from the v6.0 spec.

## Verification (from phase1-verification.txt)
- `git ls-files .venv/ runs/ egg-info/ demo-dirs`: 0
- `SECURITY-AUDIT.md`, `.codex`, `RELEASE*.md` at root: absent
- `.gitignore` IMPROVEMENTS.md occurrences: 1
- `engines.node`: `>=20.0.0`, README node badge matches
- `: any` in `src/`: 0
- Deleted demo scripts (`docker:build:health`, `docker:build:calc`, `docker:build:notes`, `docker:build:web`, `docker:build:all`, `test:python`, `test:subprojects`, `test:all`): all absent
- `npm test`: 1420 passing, 6 pending

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm test` green (1420 passing)
- [ ] CI passes on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)