### PR TITLE
feat(verifier): add cross-step, behavioral, and schema-evolution outcome checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "ink": "^4.4.1",
         "ink-spinner": "^5.0.0",
         "js-yaml": "^4.1.1",
-        "react": "^18.2.0"
+        "react": "^18.2.0",
+        "typescript": "^5.9.3"
       },
       "bin": {
         "swarm": "dist/src/cli.js",
@@ -28,7 +29,6 @@
         "mocha": "^11.7.5",
         "prettier": "^3.8.3",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
         "typescript-eslint": "^8.59.0"
       },
       "engines": {
@@ -3146,7 +3146,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -71,13 +71,13 @@
     "mocha": "^11.7.5",
     "prettier": "^3.8.3",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.0"
   },
   "dependencies": {
     "ink": "^4.4.1",
     "ink-spinner": "^5.0.0",
     "js-yaml": "^4.1.1",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/phase2-verification.txt
+++ b/phase2-verification.txt
@@ -1,0 +1,96 @@
+# Phase 2 Verification
+# Branch: feat/verifier-extensions
+# Date: 2026-04-21T14:26:15Z
+# Node: v24.12.0
+
+## New files
+  205 src/verifier/cross-step-checks.ts
+  191 src/verifier/behavioral-checks.ts
+  274 src/verifier/schema-evolution-checks.ts
+  342 test/verifier/outcome-checks-extensions.test.ts
+ 1012 total
+
+## Modified files
+ M package.json                       (typescript moved from devDeps to deps)
+ M package-lock.json
+ M src/plan-generator.ts              (PlanStep + StepIntent, validator extensions)
+ M src/swarm-orchestrator.ts          (cross-step contract gate in getReadySteps)
+ M src/verifier-engine.ts             (check-type union, opts, failure priority)
+ M src/verifier/outcome-checks.ts     (dispatch for three new checks)
+
+## Typecheck
+> swarm-orchestrator@5.0.0 typecheck
+> tsc --noEmit -p tsconfig.build.json
+
+
+## Build
+> swarm-orchestrator@5.0.0 build
+> tsc -p tsconfig.build.json && node -e "require('fs').chmodSync('dist/src/cli.js', 0o755)"
+
+
+## Lint
+> swarm-orchestrator@5.0.0 lint
+> eslint 'src/**/*.{ts,tsx}' 'test/**/*.ts'
+
+
+## New extension tests (3 per check plus framework detection = 10 total)
+    cross-step contract check
+      ✔ passes when every declared input resolves to a real, non-trivial artifact
+      ✔ fails and names the missing input when a required file is absent
+      ✔ catches the adversarial case: transcript claims success but export is undefined stub
+    behavioral preservation check
+      ✔ passes when every pre-step passing test still passes after the change (3381ms)
+      ✔ fails and names the regressed test when a previously-passing assertion now throws (3290ms)
+      ✔ catches the adversarial case: agent deletes a test and claims all pass (3253ms)
+    schema evolution check
+      ✔ passes when migration applies cleanly and probe query returns
+      ✔ fails and reports the phase when migration SQL has a syntax error
+      ✔ catches the adversarial case: migration is a no-op comment but agent claims it added the column
+    captureTestSnapshot
+      ✔ throws a descriptive error when no supported framework is detected
+
+
+  10 passing (10s)
+
+
+## Full suite
+  1430 passing (42s)
+  6 pending
+
+
+## Grep targets from the spec
+# --grep cross-step
+      ✔ fails and names the missing input when a required file is absent
+      ✔ catches the adversarial case: transcript claims success but export is undefined stub
+
+
+  3 passing (29ms)
+
+# --grep behavioral
+      ✔ fails and names the regressed test when a previously-passing assertion now throws (3275ms)
+      ✔ catches the adversarial case: agent deletes a test and claims all pass (3254ms)
+
+
+  3 passing (10s)
+
+# --grep schema-evolution
+      ✔ fails and reports the phase when migration SQL has a syntax error
+      ✔ catches the adversarial case: migration is a no-op comment but agent claims it added the column
+
+
+  3 passing (91ms)
+
+# --grep adversarial
+    schema evolution check
+      ✔ catches the adversarial case: migration is a no-op comment but agent claims it added the column
+
+
+  3 passing (3s)
+
+
+## Self-gate note
+runtime-checks reports an issue against a gitignored local benchmark artifact
+(benchmarks/harness/raw_data/runs/.../workspace/src/app.js). The failure
+reproduces on unmodified main — it is NOT introduced by this PR and will
+not trip CI, which runs on a clean checkout without that on-disk artifact.
+Pre-existing gate-scoping bug, out of Phase 2's scope.

--- a/src/plan-generator.ts
+++ b/src/plan-generator.ts
@@ -5,12 +5,20 @@ import { QualityGatesConfig } from './quality-gates/types';
 import { getLogger } from './logger';
 const logger = getLogger('plan-generator');
 
+export type StepIntent = 'implement' | 'refactor' | 'migration' | 'test' | 'docs';
+
 export interface PlanStep {
   stepNumber: number;
   agentName: string;
   task: string;
   dependencies: number[];
   expectedOutputs: string[];
+  /** Declared artifacts this step expects to consume (file paths or `file:symbol` refs). */
+  inputs?: string[];
+  /** Declared artifacts this step produces; consumable by downstream `inputs`. */
+  outputs?: string[];
+  /** Semantic tag driving which outcome checks apply (refactor, migration, etc.). */
+  intent?: StepIntent;
   repo?: string; // git URL or local path; defaults to cwd
   cliAgent?: string; // per-step adapter override (copilot, claude-code, codex)
 }
@@ -241,6 +249,24 @@ OUTPUT ONLY THE JSON, NOTHING ELSE.`;
 
       if (step.expectedOutputs.length === 0) {
         throw new Error(`Step ${index}: expectedOutputs cannot be empty`);
+      }
+
+      if (step.inputs !== undefined && !Array.isArray(step.inputs)) {
+        throw new Error(`Step ${index}: inputs must be an array of strings when present`);
+      }
+
+      if (step.outputs !== undefined && !Array.isArray(step.outputs)) {
+        throw new Error(`Step ${index}: outputs must be an array of strings when present`);
+      }
+
+      if (step.intent !== undefined) {
+        const validIntents: StepIntent[] = ['implement', 'refactor', 'migration', 'test', 'docs'];
+        if (typeof step.intent !== 'string' || !validIntents.includes(step.intent as StepIntent)) {
+          throw new Error(
+            `Step ${index}: intent must be one of ${validIntents.join(', ')} when present; ` +
+              `got "${String(step.intent)}"`,
+          );
+        }
       }
     });
 

--- a/src/swarm-orchestrator.ts
+++ b/src/swarm-orchestrator.ts
@@ -21,6 +21,7 @@ import ShareParser, { ShareIndex } from './share-parser';
 import { Spinner } from './spinner';
 import { CriticResult, SessionState } from './types';
 import VerifierEngine, { VerificationResult } from './verifier-engine';
+import { checkCrossStepContract } from './verifier/cross-step-checks';
 import { AdaptiveConcurrencyManager, WaveResizer } from './wave-resizer';
 import { CostEstimator, CostEstimate } from './cost-estimator';
 import { HookGenerator, GeneratedHooks } from './hook-generator';
@@ -440,16 +441,40 @@ export class SwarmOrchestrator {
       options?.onProgress?.(context, `step-failed:${stepNumber}`);
     };
 
-    // Returns step numbers whose dependencies are all satisfied
+    // Returns step numbers whose dependencies are all satisfied AND whose declared
+    // inputs (if any) resolve to real artifacts in the worktree. The second gate
+    // is the cross-step contract check: a step declaring `inputs: ['src/x.ts']`
+    // cannot launch until an upstream step has actually produced that file.
     const getReadySteps = (): number[] => {
       const ready: number[] = [];
       for (const stepNum of pending) {
         if (inFlight.has(stepNum)) continue;
         const step = plan.steps.find(s => s.stepNumber === stepNum);
         if (!step) continue;
-        if (step.dependencies.every(dep => completed.has(dep))) {
-          ready.push(stepNum);
+        if (!step.dependencies.every(dep => completed.has(dep))) continue;
+
+        if (step.inputs && step.inputs.length > 0) {
+          const contract = checkCrossStepContract({
+            workdir: this.workingDir,
+            requiredInputs: step.inputs,
+          });
+          if (!contract.passed) {
+            logger.warn(
+              `Step ${stepNum} blocked by cross-step contract: ${contract.reason ?? 'unknown'}`,
+            );
+            const culprits = step.dependencies.filter(dep => completed.has(dep));
+            for (const dep of culprits) {
+              completed.delete(dep);
+              failed.add(dep);
+            }
+            pending.delete(stepNum);
+            failed.add(stepNum);
+            onStepFailed(stepNum, `contract violation: ${contract.reason ?? 'unknown'}`);
+            continue;
+          }
         }
+
+        ready.push(stepNum);
       }
       return ready.sort((a, b) => a - b);
     };

--- a/src/verifier-engine.ts
+++ b/src/verifier-engine.ts
@@ -21,7 +21,8 @@ const logger = getLogger('verifier-engine');
 
 export interface VerificationCheck {
   type: 'test' | 'build' | 'lint' | 'commit' | 'claim' | 'output'
-    | 'git_diff' | 'file_existence' | 'build_exec' | 'test_exec';
+    | 'git_diff' | 'file_existence' | 'build_exec' | 'test_exec'
+    | 'cross_step_contract' | 'behavioral_preservation' | 'schema_evolution';
   description: string;
   required: boolean;
   passed: boolean;
@@ -48,6 +49,12 @@ export interface OutcomeVerificationOpts {
   workdir: string;
   baseSha: string;
   expectedFiles?: string[];
+  /** Cross-step contract inputs (file paths or `file:symbol` refs). */
+  requiredInputs?: string[];
+  /** Pre-step test snapshot for behavioral preservation on refactor steps. */
+  preTestSnapshot?: import('./verifier/behavioral-checks').TestSnapshot;
+  /** Schema evolution config for migration-intent steps. */
+  schemaEvolution?: import('./verifier/schema-evolution-checks').SchemaEvolutionOpts;
 }
 
 export interface RollbackResult {
@@ -69,10 +76,13 @@ export function last20Lines(output: string): string {
 
 // Ordering for failure context: more actionable types first
 const FAILURE_TYPE_PRIORITY: Record<string, number> = {
-  file_existence: 0,
-  test_exec: 1,
-  build_exec: 2,
-  git_diff: 3,
+  cross_step_contract: 0,
+  file_existence: 1,
+  behavioral_preservation: 2,
+  schema_evolution: 3,
+  test_exec: 4,
+  build_exec: 5,
+  git_diff: 6,
 };
 
 /**

--- a/src/verifier/behavioral-checks.ts
+++ b/src/verifier/behavioral-checks.ts
@@ -1,0 +1,191 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { VerificationCheck } from '../verifier-engine';
+import { DEFAULT_COMMAND_TIMEOUT_MS } from '../defaults';
+
+export interface TestSnapshot {
+  framework: 'mocha' | 'pytest';
+  passing: string[];
+  failing: string[];
+  skipped: string[];
+}
+
+export interface BehavioralPreservationOpts {
+  workdir: string;
+  preSnapshot: TestSnapshot;
+  postSnapshot?: TestSnapshot;
+}
+
+/**
+ * Run the project's tests and return a deterministic snapshot of test names by
+ * outcome. Supports mocha (`--reporter json`) and pytest (`-v --tb=no`).
+ * Throws a descriptive error when no supported framework is detected.
+ *
+ * Nondeterminism warning: a passing test that sometimes fails breaks snapshot
+ * comparison. We do not try to hide that; captureTestSnapshot reports the raw
+ * outcome of a single run and leaves it to the caller to handle flakiness.
+ *
+ * @param workdir Absolute path to the project under test.
+ * @throws Error when no supported framework is detected.
+ */
+export function captureTestSnapshot(workdir: string): TestSnapshot {
+  const framework = detectFramework(workdir);
+  if (!framework) {
+    throw new Error(
+      `behavioral preservation requires mocha (with --reporter json support) or pytest; ` +
+        `neither detected in ${workdir}. Add mocha or pytest as a dev dependency, or ` +
+        `remove the "refactor" intent from this step.`,
+    );
+  }
+
+  if (framework === 'mocha') return captureMocha(workdir);
+  return capturePytest(workdir);
+}
+
+/**
+ * Compare a post-step snapshot against a pre-step baseline. Fails if any test
+ * that was passing before the step is no longer passing (missing from the
+ * post-set OR moved to failing/skipped).
+ */
+export function checkBehavioralPreservation(opts: BehavioralPreservationOpts): VerificationCheck {
+  const post = opts.postSnapshot ?? captureSnapshotOrThrow(opts.workdir);
+  const preSet = new Set(opts.preSnapshot.passing);
+  const postSet = new Set(post.passing);
+
+  const regressed: string[] = [];
+  for (const name of preSet) {
+    if (!postSet.has(name)) regressed.push(name);
+  }
+
+  if (regressed.length > 0) {
+    const sample = regressed.slice(0, 5).join(', ');
+    const more = regressed.length > 5 ? ` (+${regressed.length - 5} more)` : '';
+    return {
+      type: 'behavioral_preservation',
+      description: 'Pre-existing tests still pass after refactor',
+      required: true,
+      passed: false,
+      reason: `${regressed.length} previously-passing test(s) regressed: ${sample}${more}`,
+      evidence: `pre=${preSet.size} post-passing=${postSet.size}`,
+    };
+  }
+
+  const added = post.passing.length - opts.preSnapshot.passing.length;
+  return {
+    type: 'behavioral_preservation',
+    description: 'Pre-existing tests still pass after refactor',
+    required: true,
+    passed: true,
+    evidence:
+      `All ${preSet.size} previously-passing tests still pass` +
+      (added > 0 ? ` (+${added} new passing)` : ''),
+  };
+}
+
+function captureSnapshotOrThrow(workdir: string): TestSnapshot {
+  return captureTestSnapshot(workdir);
+}
+
+function detectFramework(workdir: string): 'mocha' | 'pytest' | null {
+  const pkgPath = path.join(workdir, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+        devDependencies?: Record<string, string>;
+        dependencies?: Record<string, string>;
+      };
+      const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+      if (deps.mocha) return 'mocha';
+    } catch {
+      // malformed package.json; fall through to pytest detection
+    }
+  }
+
+  for (const marker of ['pyproject.toml', 'setup.cfg', 'requirements.txt']) {
+    const p = path.join(workdir, marker);
+    if (fs.existsSync(p) && fs.readFileSync(p, 'utf8').includes('pytest')) return 'pytest';
+  }
+
+  return null;
+}
+
+interface MochaJsonReport {
+  passes?: Array<{ fullTitle?: string; title?: string }>;
+  failures?: Array<{ fullTitle?: string; title?: string }>;
+  pending?: Array<{ fullTitle?: string; title?: string }>;
+}
+
+function captureMocha(workdir: string): TestSnapshot {
+  const raw = runAndCapture('npx --no-install mocha --reporter json', workdir);
+  const report = parseMochaJson(raw);
+  return {
+    framework: 'mocha',
+    passing: (report.passes ?? []).map(mochaName),
+    failing: (report.failures ?? []).map(mochaName),
+    skipped: (report.pending ?? []).map(mochaName),
+  };
+}
+
+function mochaName(t: { fullTitle?: string; title?: string }): string {
+  return t.fullTitle ?? t.title ?? '<unnamed>';
+}
+
+function parseMochaJson(output: string): MochaJsonReport {
+  const firstBrace = output.indexOf('{');
+  if (firstBrace < 0) {
+    throw new Error('mocha JSON reporter produced no JSON; got: ' + output.slice(0, 200));
+  }
+  const sliced = output.slice(firstBrace);
+  try {
+    return JSON.parse(sliced) as MochaJsonReport;
+  } catch (err: unknown) {
+    throw new Error('failed to parse mocha JSON output: ' + asMessage(err), { cause: err });
+  }
+}
+
+function capturePytest(workdir: string): TestSnapshot {
+  const raw = runAndCapture('python3 -m pytest -v --tb=no --no-header -q', workdir);
+  return parsePytestOutput(raw);
+}
+
+function parsePytestOutput(output: string): TestSnapshot {
+  const passing: string[] = [];
+  const failing: string[] = [];
+  const skipped: string[] = [];
+  const lineRe = /^(\S+?::\S+?)\s+(PASSED|FAILED|ERROR|SKIPPED)\b/;
+
+  for (const line of output.split('\n')) {
+    const m = lineRe.exec(line.trim());
+    if (!m) continue;
+    const [, name, status] = m;
+    if (status === 'PASSED') passing.push(name);
+    else if (status === 'SKIPPED') skipped.push(name);
+    else failing.push(name);
+  }
+
+  return { framework: 'pytest', passing, failing, skipped };
+}
+
+function runAndCapture(cmd: string, workdir: string): string {
+  try {
+    return execSync(cmd, {
+      cwd: workdir,
+      encoding: 'utf8',
+      timeout: DEFAULT_COMMAND_TIMEOUT_MS,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (err: unknown) {
+    // mocha/pytest exit non-zero when tests fail; we still want the output
+    if (err && typeof err === 'object') {
+      const e = err as { stdout?: Buffer | string };
+      if (e.stdout) return typeof e.stdout === 'string' ? e.stdout : e.stdout.toString('utf8');
+    }
+    throw new Error(`test capture failed: ${asMessage(err)}`, { cause: err });
+  }
+}
+
+function asMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/verifier/cross-step-checks.ts
+++ b/src/verifier/cross-step-checks.ts
@@ -1,0 +1,205 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+import type { VerificationCheck } from '../verifier-engine';
+
+const MIN_FILE_SIZE_BYTES = 100;
+
+export interface CrossStepContractOpts {
+  workdir: string;
+  /**
+   * Each entry is either a file path relative to `workdir` (e.g. `src/auth.ts`)
+   * or a symbol reference of the form `relative/path.ts:exportName`.
+   * The former requires existence + size > MIN_FILE_SIZE_BYTES.
+   * The latter additionally requires the TypeScript compiler to resolve the
+   * named export to a non-undefined initializer.
+   */
+  requiredInputs: string[];
+}
+
+/**
+ * Verify that every declared input of a pending step exists as a real artifact
+ * produced by an upstream step. An input is considered satisfied when:
+ *   - file refs (no `:` suffix): the file exists and is larger than
+ *     {@link MIN_FILE_SIZE_BYTES} bytes
+ *   - symbol refs (`file:name`): the file parses as TypeScript AND declares an
+ *     export named `name` whose initializer is not literal `undefined`
+ *
+ * Returns a single VerificationCheck summarising the contract.
+ *
+ * @throws never; captures internal errors as failed checks with `cause` context
+ */
+export function checkCrossStepContract(opts: CrossStepContractOpts): VerificationCheck {
+  if (opts.requiredInputs.length === 0) {
+    return {
+      type: 'cross_step_contract',
+      description: 'Cross-step inputs satisfied',
+      required: true,
+      passed: true,
+      evidence: 'No inputs declared; nothing to validate',
+    };
+  }
+
+  const missing: string[] = [];
+  const satisfied: string[] = [];
+
+  for (const ref of opts.requiredInputs) {
+    const result = resolveInput(opts.workdir, ref);
+    if (result.ok) {
+      satisfied.push(ref);
+    } else {
+      missing.push(`${ref} (${result.reason})`);
+    }
+  }
+
+  if (missing.length > 0) {
+    return {
+      type: 'cross_step_contract',
+      description: 'Cross-step inputs satisfied',
+      required: true,
+      passed: false,
+      reason: `Unsatisfied inputs: ${missing.join('; ')}`,
+      evidence: `${satisfied.length}/${opts.requiredInputs.length} inputs present`,
+    };
+  }
+
+  return {
+    type: 'cross_step_contract',
+    description: 'Cross-step inputs satisfied',
+    required: true,
+    passed: true,
+    evidence: `All ${satisfied.length} declared input(s) verified`,
+  };
+}
+
+interface ResolveResult {
+  ok: boolean;
+  reason: string;
+}
+
+function resolveInput(workdir: string, ref: string): ResolveResult {
+  const isSymbolRef = ref.includes(':');
+  const [relativePath, symbolName] = isSymbolRef ? ref.split(':', 2) : [ref, undefined];
+  const fullPath = path.join(workdir, relativePath);
+
+  if (!fs.existsSync(fullPath)) {
+    return { ok: false, reason: 'file not found' };
+  }
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(fullPath);
+  } catch (err: unknown) {
+    return { ok: false, reason: `stat failed: ${asMessage(err)}` };
+  }
+
+  if (!stat.isFile()) {
+    return { ok: false, reason: 'path is not a regular file' };
+  }
+
+  if (stat.size <= MIN_FILE_SIZE_BYTES) {
+    return { ok: false, reason: `file size ${stat.size}B ≤ ${MIN_FILE_SIZE_BYTES}B threshold` };
+  }
+
+  if (!isSymbolRef) {
+    return { ok: true, reason: 'file present and non-trivial' };
+  }
+
+  return resolveSymbol(fullPath, symbolName!);
+}
+
+function resolveSymbol(filePath: string, symbolName: string): ResolveResult {
+  let source: string;
+  try {
+    source = fs.readFileSync(filePath, 'utf8');
+  } catch (err: unknown) {
+    return { ok: false, reason: `read failed: ${asMessage(err)}` };
+  }
+
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.ES2022,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const found = findExportedSymbol(sourceFile, symbolName);
+  if (!found) {
+    return { ok: false, reason: `no export named "${symbolName}"` };
+  }
+
+  if (found.isUndefinedInitializer) {
+    return { ok: false, reason: `export "${symbolName}" is literal undefined` };
+  }
+
+  return { ok: true, reason: `export "${symbolName}" resolved` };
+}
+
+interface SymbolResolution {
+  isUndefinedInitializer: boolean;
+}
+
+function findExportedSymbol(source: ts.SourceFile, name: string): SymbolResolution | null {
+  let found: SymbolResolution | null = null;
+
+  ts.forEachChild(source, (node) => {
+    if (found) return;
+    const hit = matchNode(node, name);
+    if (hit) found = hit;
+  });
+
+  return found;
+}
+
+function matchNode(node: ts.Node, name: string): SymbolResolution | null {
+  if (ts.isFunctionDeclaration(node) && hasExportModifier(node) && node.name?.text === name) {
+    return { isUndefinedInitializer: false };
+  }
+
+  if (ts.isClassDeclaration(node) && hasExportModifier(node) && node.name?.text === name) {
+    return { isUndefinedInitializer: false };
+  }
+
+  if (ts.isInterfaceDeclaration(node) && hasExportModifier(node) && node.name.text === name) {
+    return { isUndefinedInitializer: false };
+  }
+
+  if (ts.isTypeAliasDeclaration(node) && hasExportModifier(node) && node.name.text === name) {
+    return { isUndefinedInitializer: false };
+  }
+
+  if (ts.isVariableStatement(node) && hasExportModifier(node)) {
+    for (const decl of node.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || decl.name.text !== name) continue;
+      const init = decl.initializer;
+      const isUndef = !init || (ts.isIdentifier(init) && init.text === 'undefined');
+      return { isUndefinedInitializer: isUndef };
+    }
+  }
+
+  if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
+    for (const el of node.exportClause.elements) {
+      if (el.name.text === name) {
+        return { isUndefinedInitializer: false };
+      }
+    }
+  }
+
+  if (ts.isExportAssignment(node) && !node.isExportEquals) {
+    if (ts.isIdentifier(node.expression) && node.expression.text === name) {
+      return { isUndefinedInitializer: false };
+    }
+  }
+
+  return null;
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+  return modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+}
+
+function asMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/verifier/outcome-checks.ts
+++ b/src/verifier/outcome-checks.ts
@@ -9,6 +9,9 @@ import {
   DEFAULT_COMMAND_TIMEOUT_MS,
   DEFAULT_SIGKILL_DELAY_MS,
 } from '../defaults';
+import { checkCrossStepContract } from './cross-step-checks';
+import { checkBehavioralPreservation } from './behavioral-checks';
+import { checkSchemaEvolution } from './schema-evolution-checks';
 
 function last20Lines(output: string): string {
   const lines = output.split('\n');
@@ -26,6 +29,25 @@ export function runOutcomeChecks(
 
   if (opts.expectedFiles && opts.expectedFiles.length > 0) {
     checks.push(checkFileExistence(opts.workdir, opts.expectedFiles));
+  }
+
+  if (opts.requiredInputs && opts.requiredInputs.length > 0) {
+    checks.push(
+      checkCrossStepContract({ workdir: opts.workdir, requiredInputs: opts.requiredInputs }),
+    );
+  }
+
+  if (opts.preTestSnapshot) {
+    checks.push(
+      checkBehavioralPreservation({
+        workdir: opts.workdir,
+        preSnapshot: opts.preTestSnapshot,
+      }),
+    );
+  }
+
+  if (opts.schemaEvolution) {
+    checks.push(checkSchemaEvolution(opts.schemaEvolution));
   }
 
   const buildCheck = checkBuildExec(opts.workdir);

--- a/src/verifier/schema-evolution-checks.ts
+++ b/src/verifier/schema-evolution-checks.ts
@@ -1,0 +1,274 @@
+import { execFileSync, execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { VerificationCheck } from '../verifier-engine';
+
+export type MigrationBackend = 'sqlite' | 'postgres';
+
+export interface SchemaEvolutionOpts {
+  workdir: string;
+  backend: MigrationBackend;
+  /** Pre-migration schema SQL (applied before the migration under test). */
+  seedSchema: string;
+  /** Path to the migration SQL file, relative to workdir. */
+  migrationFile: string;
+  /** SQL executed after the migration; must succeed for the check to pass. */
+  probeQuery: string;
+  /** Postgres image override; ignored for sqlite backend. */
+  postgresImage?: string;
+}
+
+/**
+ * Apply a migration against a freshly-seeded database and run a probe query.
+ * Pass when the migration applies cleanly AND the probe returns without error.
+ * Fail otherwise, surfacing the real stderr from the database engine.
+ *
+ * The SQLite backend shells out to the system `sqlite3` CLI against an
+ * ephemeral temp-file DB. The Postgres backend spins up a disposable Docker
+ * container (image defaults to `postgres:15-alpine`), waits for readiness, and
+ * runs migration + probe via `psql` inside the container.
+ *
+ * @throws never; all failure modes are returned as a failing VerificationCheck
+ */
+export function checkSchemaEvolution(opts: SchemaEvolutionOpts): VerificationCheck {
+  const migrationPath = path.resolve(opts.workdir, opts.migrationFile);
+  if (!fs.existsSync(migrationPath)) {
+    return {
+      type: 'schema_evolution',
+      description: 'Migration applies cleanly and probe query succeeds',
+      required: true,
+      passed: false,
+      reason: `Migration file not found: ${opts.migrationFile}`,
+    };
+  }
+
+  const migrationSql = fs.readFileSync(migrationPath, 'utf8');
+
+  if (opts.backend === 'sqlite') {
+    return runSqlite(opts.seedSchema, migrationSql, opts.probeQuery);
+  }
+  return runPostgres(
+    opts.seedSchema,
+    migrationSql,
+    opts.probeQuery,
+    opts.postgresImage ?? 'postgres:15-alpine',
+  );
+}
+
+function runSqlite(seed: string, migration: string, probe: string): VerificationCheck {
+  const dbFile = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'schema-evo-')),
+    'check.db',
+  );
+
+  try {
+    applySqlite(dbFile, seed, 'seed');
+    applySqlite(dbFile, migration, 'migration');
+    const probeOutput = applySqlite(dbFile, probe, 'probe');
+
+    return {
+      type: 'schema_evolution',
+      description: 'Migration applies cleanly and probe query succeeds',
+      required: true,
+      passed: true,
+      evidence: probeOutput
+        ? `probe output: ${probeOutput.slice(0, 200)}`
+        : 'probe ran without error',
+    };
+  } catch (err: unknown) {
+    const e = err as { phase?: string; message?: string };
+    return {
+      type: 'schema_evolution',
+      description: 'Migration applies cleanly and probe query succeeds',
+      required: true,
+      passed: false,
+      reason: `${e.phase ?? 'unknown-phase'} failed: ${e.message ?? String(err)}`,
+    };
+  } finally {
+    try {
+      fs.rmSync(path.dirname(dbFile), { recursive: true, force: true });
+    } catch {
+      // tempdir cleanup is best-effort
+    }
+  }
+}
+
+interface PhaseError extends Error {
+  phase: string;
+}
+
+function phaseError(phase: string, message: string, cause?: unknown): PhaseError {
+  const err = new Error(message, cause !== undefined ? { cause } : {}) as PhaseError;
+  err.phase = phase;
+  return err;
+}
+
+function applySqlite(dbFile: string, sql: string, phase: string): string {
+  if (!sql.trim()) return '';
+  try {
+    return execFileSync('sqlite3', [dbFile], {
+      input: sql,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 15_000,
+    });
+  } catch (err: unknown) {
+    const stderr = extractStderr(err);
+    throw phaseError(phase, stderr || asMessage(err), err);
+  }
+}
+
+function runPostgres(
+  seed: string,
+  migration: string,
+  probe: string,
+  image: string,
+): VerificationCheck {
+  if (!dockerAvailable()) {
+    return {
+      type: 'schema_evolution',
+      description: 'Migration applies cleanly and probe query succeeds',
+      required: true,
+      passed: false,
+      reason:
+        'postgres backend requires Docker but `docker ps` failed. Install Docker or ' +
+        'set backend: "sqlite" for SQLite projects.',
+    };
+  }
+
+  const containerName = `schema-evo-${process.pid}-${Date.now()}`;
+  try {
+    execFileSync(
+      'docker',
+      [
+        'run',
+        '--rm',
+        '-d',
+        '--name',
+        containerName,
+        '-e',
+        'POSTGRES_PASSWORD=swarm',
+        '-e',
+        'POSTGRES_DB=swarm_eval',
+        image,
+      ],
+      { stdio: ['pipe', 'pipe', 'pipe'], timeout: 60_000 },
+    );
+
+    waitForPostgresReady(containerName);
+
+    applyPsql(containerName, seed, 'seed');
+    applyPsql(containerName, migration, 'migration');
+    const probeOutput = applyPsql(containerName, probe, 'probe');
+
+    return {
+      type: 'schema_evolution',
+      description: 'Migration applies cleanly and probe query succeeds',
+      required: true,
+      passed: true,
+      evidence: probeOutput
+        ? `probe output: ${probeOutput.slice(0, 200)}`
+        : 'probe ran without error',
+    };
+  } catch (err: unknown) {
+    const e = err as { phase?: string; message?: string };
+    return {
+      type: 'schema_evolution',
+      description: 'Migration applies cleanly and probe query succeeds',
+      required: true,
+      passed: false,
+      reason: `${e.phase ?? 'unknown-phase'} failed: ${e.message ?? String(err)}`,
+    };
+  } finally {
+    try {
+      execFileSync('docker', ['rm', '-f', containerName], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 30_000,
+      });
+    } catch {
+      // container may already be gone; tear-down is best-effort
+    }
+  }
+}
+
+function dockerAvailable(): boolean {
+  try {
+    execSync('docker ps', { stdio: ['pipe', 'pipe', 'pipe'], timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function waitForPostgresReady(containerName: string): void {
+  const start = Date.now();
+  const timeoutMs = 30_000;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      execFileSync(
+        'docker',
+        ['exec', containerName, 'pg_isready', '-U', 'postgres'],
+        { stdio: ['pipe', 'pipe', 'pipe'], timeout: 5_000 },
+      );
+      return;
+    } catch {
+      // pg_isready exits non-zero until the server accepts connections
+    }
+    sleepMs(500);
+  }
+  throw phaseError('bringup', `postgres not ready after ${timeoutMs}ms`);
+}
+
+function sleepMs(ms: number): void {
+  execFileSync('sleep', [(ms / 1000).toString()], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: ms + 1000,
+  });
+}
+
+function applyPsql(containerName: string, sql: string, phase: string): string {
+  if (!sql.trim()) return '';
+  try {
+    return execFileSync(
+      'docker',
+      [
+        'exec',
+        '-i',
+        containerName,
+        'psql',
+        '-U',
+        'postgres',
+        '-d',
+        'swarm_eval',
+        '-v',
+        'ON_ERROR_STOP=1',
+        '-q',
+      ],
+      {
+        input: sql,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 30_000,
+      },
+    );
+  } catch (err: unknown) {
+    const stderr = extractStderr(err);
+    throw phaseError(phase, stderr || asMessage(err), err);
+  }
+}
+
+function extractStderr(err: unknown): string {
+  if (err && typeof err === 'object') {
+    const e = err as { stderr?: Buffer | string; stdout?: Buffer | string };
+    const out: string[] = [];
+    if (e.stdout) out.push(typeof e.stdout === 'string' ? e.stdout : e.stdout.toString('utf8'));
+    if (e.stderr) out.push(typeof e.stderr === 'string' ? e.stderr : e.stderr.toString('utf8'));
+    return out.join('\n').trim();
+  }
+  return '';
+}
+
+function asMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/test/verifier/outcome-checks-extensions.test.ts
+++ b/test/verifier/outcome-checks-extensions.test.ts
@@ -1,0 +1,342 @@
+import { strict as assert } from 'assert';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { checkCrossStepContract } from '../../src/verifier/cross-step-checks';
+import {
+  captureTestSnapshot,
+  checkBehavioralPreservation,
+} from '../../src/verifier/behavioral-checks';
+import { checkSchemaEvolution } from '../../src/verifier/schema-evolution-checks';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+}
+
+function sqliteAvailable(): boolean {
+  try {
+    execFileSync('sqlite3', ['-version'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Scaffold a standalone mocha-using fixture project. Symlinks node_modules from
+ * the host repo so real mocha is resolvable. Returns the project root path.
+ */
+function scaffoldMochaFixture(dir: string): void {
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'behavioral-fixture',
+        version: '0.0.0',
+        private: true,
+        scripts: { test: 'mocha' },
+        devDependencies: { mocha: '^11.0.0' },
+      },
+      null,
+      2,
+    ),
+  );
+  fs.mkdirSync(path.join(dir, 'test'));
+  fs.symlinkSync(path.join(REPO_ROOT, 'node_modules'), path.join(dir, 'node_modules'), 'dir');
+}
+
+function writeMochaTest(dir: string, name: string, body: string): void {
+  fs.writeFileSync(path.join(dir, 'test', `${name}.test.js`), body);
+}
+
+describe('Outcome check extensions', () => {
+  let scratch: string[] = [];
+
+  afterEach(() => {
+    for (const d of scratch) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        // scratch cleanup is best-effort
+      }
+    }
+    scratch = [];
+  });
+
+  // ── 2.1 Cross-step contract validation ──────────────────────────
+
+  describe('cross-step contract check', () => {
+    it('passes when every declared input resolves to a real, non-trivial artifact', () => {
+      const dir = tmpDir('xstep-pass');
+      scratch.push(dir);
+      fs.mkdirSync(path.join(dir, 'src'));
+      const content = `export function authenticate(user: string): boolean {
+  return user.length > 0 && user !== 'anonymous';
+}
+
+export interface AuthConfig {
+  secretKey: string;
+  issuer: string;
+}
+`;
+      fs.writeFileSync(path.join(dir, 'src', 'auth.ts'), content);
+
+      const check = checkCrossStepContract({
+        workdir: dir,
+        requiredInputs: ['src/auth.ts', 'src/auth.ts:authenticate', 'src/auth.ts:AuthConfig'],
+      });
+
+      assert.strictEqual(check.passed, true, check.reason ?? 'expected pass');
+      assert.match(check.evidence ?? '', /3 declared input/);
+    });
+
+    it('fails and names the missing input when a required file is absent', () => {
+      const dir = tmpDir('xstep-fail');
+      scratch.push(dir);
+      fs.mkdirSync(path.join(dir, 'src'));
+      fs.writeFileSync(
+        path.join(dir, 'src', 'present.ts'),
+        'export const present = true;\n// padding '.padEnd(150, 'x') + '\n',
+      );
+
+      const check = checkCrossStepContract({
+        workdir: dir,
+        requiredInputs: ['src/present.ts', 'src/missing.ts'],
+      });
+
+      assert.strictEqual(check.passed, false);
+      assert.match(check.reason ?? '', /src\/missing\.ts.*file not found/);
+    });
+
+    it('catches the adversarial case: transcript claims success but export is undefined stub', () => {
+      // Agent's transcript would claim it implemented `authenticate`. Reality:
+      // the file exists and has a stub that binds the export to literal undefined.
+      // A file-existence-only check would pass this; the symbol resolver must
+      // catch the empty binding.
+      const dir = tmpDir('xstep-adv');
+      scratch.push(dir);
+      fs.mkdirSync(path.join(dir, 'src'));
+      const stub = `// Agent said: "Implemented authenticate()"
+// Reality: stub returns undefined
+export const authenticate = undefined;
+// Padding so the file clears the 100B size gate and would fool a naive check
+${'// '.padEnd(200, 'x')}
+`;
+      fs.writeFileSync(path.join(dir, 'src', 'auth.ts'), stub);
+
+      const check = checkCrossStepContract({
+        workdir: dir,
+        requiredInputs: ['src/auth.ts:authenticate'],
+      });
+
+      assert.strictEqual(check.passed, false, 'adversarial stub must be caught');
+      assert.match(check.reason ?? '', /literal undefined/);
+    });
+  });
+
+  // ── 2.2 Behavioral preservation ─────────────────────────────────
+
+  describe('behavioral preservation check', function () {
+    this.timeout(60_000); // each case spawns mocha twice against a real fixture
+
+    it('passes when every pre-step passing test still passes after the change', () => {
+      const dir = tmpDir('behav-pass');
+      scratch.push(dir);
+      scaffoldMochaFixture(dir);
+      writeMochaTest(
+        dir,
+        'addition',
+        `const assert = require('assert');
+describe('math', () => {
+  it('adds', () => assert.strictEqual(1 + 1, 2));
+  it('multiplies', () => assert.strictEqual(2 * 3, 6));
+});
+`,
+      );
+
+      const pre = captureTestSnapshot(dir);
+      assert.strictEqual(pre.passing.length, 2, 'fixture should report 2 passing pre-snapshot');
+
+      writeMochaTest(
+        dir,
+        'subtraction',
+        `const assert = require('assert');
+describe('math', () => {
+  it('subtracts', () => assert.strictEqual(5 - 2, 3));
+});
+`,
+      );
+
+      const check = checkBehavioralPreservation({ workdir: dir, preSnapshot: pre });
+
+      assert.strictEqual(check.passed, true, check.reason ?? 'expected pass');
+      assert.match(check.evidence ?? '', /1 new passing/);
+    });
+
+    it('fails and names the regressed test when a previously-passing assertion now throws', () => {
+      const dir = tmpDir('behav-fail');
+      scratch.push(dir);
+      scaffoldMochaFixture(dir);
+      writeMochaTest(
+        dir,
+        'addition',
+        `const assert = require('assert');
+describe('math', () => {
+  it('adds', () => assert.strictEqual(1 + 1, 2));
+  it('multiplies', () => assert.strictEqual(2 * 3, 6));
+});
+`,
+      );
+
+      const pre = captureTestSnapshot(dir);
+      assert.strictEqual(pre.passing.length, 2);
+
+      // "Refactor" breaks the multiplies test
+      writeMochaTest(
+        dir,
+        'addition',
+        `const assert = require('assert');
+describe('math', () => {
+  it('adds', () => assert.strictEqual(1 + 1, 2));
+  it('multiplies', () => assert.strictEqual(2 * 3, 7)); // wrong
+});
+`,
+      );
+
+      const check = checkBehavioralPreservation({ workdir: dir, preSnapshot: pre });
+
+      assert.strictEqual(check.passed, false);
+      assert.match(check.reason ?? '', /math multiplies/);
+    });
+
+    it('catches the adversarial case: agent deletes a test and claims all pass', () => {
+      // Single-snapshot count-based checks get fooled by this: the remaining
+      // tests all pass, so naive "all passing" would return pass. We compare
+      // against the pre-step *set* of test names, so a removed test trips the
+      // regression detector even though the post-run has zero failures.
+      const dir = tmpDir('behav-adv');
+      scratch.push(dir);
+      scaffoldMochaFixture(dir);
+      writeMochaTest(
+        dir,
+        'pair',
+        `const assert = require('assert');
+describe('pair', () => {
+  it('lhs', () => assert.strictEqual('a', 'a'));
+  it('rhs', () => assert.strictEqual('b', 'b'));
+});
+`,
+      );
+
+      const pre = captureTestSnapshot(dir);
+      assert.strictEqual(pre.passing.length, 2);
+
+      // Agent "refactors" and removes the rhs case entirely, then claims success
+      writeMochaTest(
+        dir,
+        'pair',
+        `const assert = require('assert');
+describe('pair', () => {
+  it('lhs', () => assert.strictEqual('a', 'a'));
+});
+`,
+      );
+
+      const check = checkBehavioralPreservation({ workdir: dir, preSnapshot: pre });
+
+      assert.strictEqual(check.passed, false, 'silently-dropped test must be caught');
+      assert.match(check.reason ?? '', /pair rhs/);
+    });
+  });
+
+  // ── 2.3 Schema evolution ────────────────────────────────────────
+
+  describe('schema evolution check', () => {
+    before(function skipWithoutSqlite() {
+      if (!sqliteAvailable()) this.skip();
+    });
+
+    it('passes when migration applies cleanly and probe query returns', () => {
+      const dir = tmpDir('schema-pass');
+      scratch.push(dir);
+      const migrationPath = path.join(dir, 'add_email.sql');
+      fs.writeFileSync(migrationPath, 'ALTER TABLE users ADD COLUMN email TEXT;\n');
+
+      const check = checkSchemaEvolution({
+        workdir: dir,
+        backend: 'sqlite',
+        seedSchema:
+          'CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);\n' +
+          "INSERT INTO users (name) VALUES ('alice');\n",
+        migrationFile: 'add_email.sql',
+        probeQuery: 'SELECT email FROM users LIMIT 1;',
+      });
+
+      assert.strictEqual(check.passed, true, check.reason ?? 'expected pass');
+    });
+
+    it('fails and reports the phase when migration SQL has a syntax error', () => {
+      const dir = tmpDir('schema-fail');
+      scratch.push(dir);
+      const migrationPath = path.join(dir, 'bad.sql');
+      fs.writeFileSync(migrationPath, 'ALTRR TABLE users ADD COLUMN email TEXT;\n');
+
+      const check = checkSchemaEvolution({
+        workdir: dir,
+        backend: 'sqlite',
+        seedSchema: 'CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);\n',
+        migrationFile: 'bad.sql',
+        probeQuery: 'SELECT 1;',
+      });
+
+      assert.strictEqual(check.passed, false);
+      assert.match(check.reason ?? '', /migration failed/);
+    });
+
+    it('catches the adversarial case: migration is a no-op comment but agent claims it added the column', () => {
+      // A verifier that only checks "did the SQL run without error" passes this
+      // (comments run fine). The probe query against the non-existent column is
+      // the real correctness signal; only running it against a live DB catches
+      // the lie.
+      const dir = tmpDir('schema-adv');
+      scratch.push(dir);
+      const migrationPath = path.join(dir, 'pretend_add_email.sql');
+      fs.writeFileSync(
+        migrationPath,
+        '-- Agent said: "Added email column to users"\n' +
+          '-- Reality: the migration is empty; the column was never added.\n' +
+          'SELECT 1;\n',
+      );
+
+      const check = checkSchemaEvolution({
+        workdir: dir,
+        backend: 'sqlite',
+        seedSchema: 'CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);\n',
+        migrationFile: 'pretend_add_email.sql',
+        probeQuery: 'SELECT email FROM users LIMIT 1;',
+      });
+
+      assert.strictEqual(check.passed, false, 'missing-column lie must be caught');
+      assert.match(check.reason ?? '', /probe failed.*email/);
+    });
+  });
+
+  // ── Framework-detection error surface ───────────────────────────
+
+  describe('captureTestSnapshot', () => {
+    it('throws a descriptive error when no supported framework is detected', () => {
+      const dir = tmpDir('nofw');
+      scratch.push(dir);
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'bare' }));
+
+      assert.throws(
+        () => captureTestSnapshot(dir),
+        /requires mocha.*or pytest/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Three new outcome-verification checks, each running against real artifacts (no mocks). All adversarial test cases catch planted lies that naive existence/exit-code checks would miss.
- **cross-step contract** validates declared `inputs` resolve to real files (>100B) or real TypeScript exports (non-undefined) via the compiler API. Wired into the scheduler: a step with unsatisfied inputs does not launch; the culprit dep is sent to the failure queue.
- **behavioral preservation** snapshots passing test names (mocha `--reporter json` or pytest) before a `refactor` step and compares the post-set. Catches silently-dropped tests, not just failing ones.
- **schema evolution** seeds an ephemeral real DB (system `sqlite3` CLI, or a disposable postgres container), applies the migration, runs a probe query. A no-op migration that claims to add a column is caught because the probe against the missing column errors.

## Schema changes
- `PlanStep`: optional `inputs`, `outputs`, `intent` (`implement`/`refactor`/`migration`/`test`/`docs`)
- `VerificationCheck.type`: adds `cross_step_contract` | `behavioral_preservation` | `schema_evolution`
- `OutcomeVerificationOpts`: adds `requiredInputs`, `preTestSnapshot`, `schemaEvolution`
- `typescript` moved from devDependencies to dependencies (runtime dep of the symbol resolver)

## Tests (test/verifier/outcome-checks-extensions.test.ts)
Three cases per check — passing, failing, adversarial — plus framework detection. Adversarial cases:
- `cross-step`: file exists and is non-trivial but `export const authenticate = undefined` — caught by symbol resolver
- `behavioral`: agent deletes a test and claims all pass — caught by set comparison against pre-snapshot
- `schema`: migration is `-- comment; SELECT 1;` that claims to add a column — caught by probe query on the missing column

Full suite: **1420 → 1430 passing, 0 regressions.**

## Verification (phase2-verification.txt)
- `npm run typecheck`: clean
- `npm run build`: clean
- `npm run lint`: clean
- `npm test`: 1430 passing, 6 pending
- Extension tests by grep: cross-step / behavioral preservation / schema evolution / adversarial — all green

## Notes
- `benchmarks/harness/raw_data/runs/.../workspace/src/app.js` trips the runtime-checks self-gate locally. That file is gitignored and reproduces the failure on unmodified `main`; it is not introduced by this PR and will not trip CI, which runs on a clean checkout without the on-disk artifact. Pre-existing gate-scoping bug, out of Phase 2's scope.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` 1430 passing
- [x] Adversarial tests catch planted lies for all three checks
- [ ] CI passes on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)