### PR TITLE
fix(verifier): scope pytest rootdir + ignore runs/ subtree

### DIFF
--- a/fix-defect-c-verification.txt
+++ b/fix-defect-c-verification.txt
@@ -1,0 +1,32 @@
+# Defect (c) Verification — pytest rootdir isolation
+# Branch: fix/pytest-rootdir-isolation
+# Date: 2026-04-21T18:42:28Z
+
+## What changed
+  src/verifier/outcome-checks.ts  pytestCmd() now emits
+    'python3 -m pytest --rootdir="<workdir>" --ignore="<runs>" --ignore="<.swarm>"'
+  Only the verifier's outcome-check pytest invocation is modified. The
+  agent's own test commands during step execution are untouched —
+  those are captured by transcript-parsing, not by this code path.
+
+## Typecheck
+> tsc --noEmit -p tsconfig.build.json
+
+
+## Lint
+> eslint 'src/**/*.{ts,tsx}' 'test/**/*.ts'
+
+
+## Regression test (proves both the precondition and the fix)
+  Outcome-Based Verification
+    pytest rootdir isolation (defect c regression)
+      ✔ does not double-collect a conftest.py hidden inside an orchestrator runs/ subtree (1732ms)
+
+
+  1 passing (2s)
+
+
+## Full suite
+  1421 passing (31s)
+  6 pending
+

--- a/src/verifier/outcome-checks.ts
+++ b/src/verifier/outcome-checks.ts
@@ -265,7 +265,26 @@ function detectTestCommand(workdir: string, workingDir: string): string | null {
   }
 
   const makefilePath = path.join(workdir, 'Makefile');
-  const pytestCmd = () => `${resolvePythonBinary(workdir, workingDir)} -m pytest`;
+  // pytest is invoked by the verifier, NOT the agent. When the agent runs
+  // tests inside its worktree, it does so via its own shell commands; those
+  // are transcribed and transcript-parsed by the verifyTests path. This pytest
+  // invocation is the outcome-check path, and it must be isolated from
+  // orchestrator-generated artifact trees:
+  //   - --rootdir="<workdir>" scopes pytest's rootdir search to the repo root
+  //     instead of walking up to a common ancestor with parent worktrees (the
+  //     shape that caused sympy__sympy-12481 to fail on double-collection of
+  //     conftest.py).
+  //   - --ignore paths prevent pytest from descending into orchestrator
+  //     artifact trees whose own conftest.py would re-register options.
+  const pytestCmd = () => {
+    const py = resolvePythonBinary(workdir, workingDir);
+    const runsDir = path.join(workdir, 'runs');
+    const swarmDir = path.join(workdir, '.swarm');
+    return (
+      `${py} -m pytest --rootdir="${workdir}" ` +
+      `--ignore="${runsDir}" --ignore="${swarmDir}"`
+    );
+  };
 
   const pyprojectPath = path.join(workdir, 'pyproject.toml');
   if (fs.existsSync(pyprojectPath)) {

--- a/test/outcome-verification.test.ts
+++ b/test/outcome-verification.test.ts
@@ -622,4 +622,105 @@ Compiled successfully
       assert.strictEqual(testCheck!.passed, true);
     });
   });
+
+  describe('pytest rootdir isolation (defect c regression)', function () {
+    // Spawns real pytest; allow headroom
+    this.timeout(30_000);
+
+    function pytestAvailable(): boolean {
+      try {
+        execSync('python3 -m pytest --version', { stdio: ['pipe', 'pipe', 'pipe'] });
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    before(function () {
+      if (!pytestAvailable()) this.skip();
+    });
+
+    it('does not double-collect a conftest.py hidden inside an orchestrator runs/ subtree', async () => {
+      // Reproduces the sympy__sympy-12481 pilot failure: a repo whose conftest
+      // defines pytest options, with a worktree under `runs/` that contains a
+      // copy of the same conftest. Without --rootdir + --ignore, pytest's
+      // rootdir search walks up and registers BOTH conftests, tripping
+      // `ValueError: option names {'--slow'} already added`.
+      const dir = tmpDir();
+      tempDirs.push(dir);
+      const baseSha = initGitRepo(dir);
+
+      const conftest = `
+import pytest
+def pytest_addoption(parser):
+    parser.addoption("--slow", dest="runslow", action="store_true",
+                     default=False, help="run slow tests")
+`;
+      fs.writeFileSync(path.join(dir, 'conftest.py'), conftest);
+      fs.writeFileSync(
+        path.join(dir, 'test_trivial.py'),
+        'def test_two_plus_two():\n    assert 2 + 2 == 4\n',
+      );
+      fs.writeFileSync(
+        path.join(dir, 'requirements.txt'),
+        'pytest\n',
+      );
+
+      // Simulate the orchestrator's worktree shape: runs/swarm-*/worktrees/step-1
+      // gets the same conftest (because the worktree is effectively a copy of
+      // the repo tree for that branch). Pre-fix, pytest discovered both.
+      const worktreePath = path.join(dir, 'runs', 'swarm-regression', 'worktrees', 'step-1');
+      fs.mkdirSync(worktreePath, { recursive: true });
+      fs.writeFileSync(path.join(worktreePath, 'conftest.py'), conftest);
+      fs.writeFileSync(
+        path.join(worktreePath, 'test_trivial.py'),
+        'def test_three_plus_three():\n    assert 3 + 3 == 6\n',
+      );
+
+      execSync('git add . && git commit -m "seed"', {
+        cwd: dir,
+        env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t',
+               GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
+      });
+
+      // Sanity check: the pre-fix invocation (no flags) actually errors on
+      // the double-registration. This locks in *why* the fix is needed.
+      let preFixRaised = false;
+      try {
+        execSync('python3 -m pytest', {
+          cwd: dir, stdio: ['pipe', 'pipe', 'pipe'], timeout: 15_000,
+        });
+      } catch (err: unknown) {
+        const out = (err as { stdout?: Buffer; stderr?: Buffer });
+        const msg =
+          (out.stdout ? out.stdout.toString() : '') +
+          (out.stderr ? out.stderr.toString() : '');
+        if (/option names \{'--slow'\} already added/.test(msg)) {
+          preFixRaised = true;
+        }
+      }
+      assert.ok(
+        preFixRaised,
+        'precondition: the raw `python3 -m pytest` invocation must trip the ' +
+          'double-registration error for this test to prove anything',
+      );
+
+      // Now run via the verifier — the fixed pytestCmd includes --rootdir and
+      // --ignore, which must suppress the double-collection.
+      const transcript = writeTranscript(dir);
+      const verifier = new VerifierEngine(dir);
+      const result = await verifier.verifyStep(
+        1, 'dev', transcript, undefined, undefined, undefined,
+        { workdir: dir, baseSha },
+      );
+
+      const testCheck = result.checks.find(c => c.type === 'test_exec');
+      assert.ok(testCheck, 'verifier should have produced a test_exec check');
+      assert.strictEqual(
+        testCheck!.passed,
+        true,
+        `verifier must succeed despite the parent-worktree conftest: ${testCheck!.reason ?? ''}`,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- The verifier's outcome-check pytest invocation had no `--rootdir`. When the orchestrator has a worktree under `runs/swarm-*/worktrees/step-N/` with a copy of the repo's `conftest.py`, pytest's default rootdir search walked up to a common ancestor and registered **both** conftests. Duplicated `pytest_addoption(--slow)` tripped `ValueError: option names {'--slow'} already added` and the test_exec check falsely reported a test failure.
- Surfaced by the Phase 4a SWE-bench smoke on `sympy__sympy-12481`.

## Change
`pytestCmd()` in `src/verifier/outcome-checks.ts` now emits:
```
python3 -m pytest --rootdir="<workdir>" --ignore="<workdir>/runs" --ignore="<workdir>/.swarm"
```

## Isolation
Change affects **only** the verifier's own pytest invocation (the outcome-check `test_exec` path). The agent's own test commands during step execution are transcript-parsed in `transcript-checks.ts`, which is untouched. Per Brad's constraint: the flag must reach the verification pytest run, not the agent's own.

## Regression test
`test/outcome-verification.test.ts` reproduces the exact double-conftest shape and asserts **two** things:
1. **Precondition:** a raw `python3 -m pytest` invocation *does* trip the `option names {'--slow'} already added` error. This proves the fixture actually captures the bug.
2. The fixed verifier path succeeds despite the parent-worktree conftest.

If anyone removes `--rootdir` or `--ignore` in the future, the test fails immediately.

## Suite
**1420 → 1421 passing, 0 regressions.** typecheck + lint clean.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` 1421 passing
- [x] Precondition + fix both asserted in the regression
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)