### PR TITLE
fix(bench): bytes-safe capture_agent_diff with size + empty guardrails

### DIFF
--- a/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
+++ b/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
@@ -49,6 +49,78 @@ CACHE_DIR = Path(os.environ.get("HF_HOME", str(_REPO_ROOT / ".cache" / "huggingf
 
 
 # ---------------------------------------------------------------------------
+# Diff capture (bytes-safe, with size guardrails)
+# ---------------------------------------------------------------------------
+
+# Soft ceiling on agent-diff size. A diff this large is almost always scope
+# pollution (build output, vendor trees, upstream source re-emitted) rather
+# than the agent's actual work, and shipping it downstream would either fail
+# to apply or waste real money on a doomed evaluation. Fail loud instead.
+MAX_DIFF_BYTES = 10 * 1024 * 1024
+
+
+class DiffCaptureError(RuntimeError):
+    """Raised when capture_agent_diff produces a diff that cannot be trusted.
+
+    Empty diffs mean the agent made no changes — a real failure mode worth
+    surfacing rather than handing a zero-byte patch to the downstream
+    evaluator. Oversized diffs mean the intent-to-add scope pulled in noise
+    that would waste cycles (and potentially premium requests) on apply
+    failures.
+    """
+
+
+def capture_agent_diff(repo_dir: Path, base_commit: str) -> bytes:
+    """Collect the agent's changes as a unified diff against the base commit.
+
+    Returns raw bytes. `git diff` output can contain non-UTF-8 content —
+    filenames in legacy encodings, binary-file marker lines with byte-level
+    metadata, or text files that aren't clean UTF-8 (latin-1 residue in
+    older repos, test fixtures with arbitrary byte sequences). Decoding at
+    capture time raises UnicodeDecodeError on real-world workdirs; callers
+    that need a string should decode at the point of use with
+    errors='replace' so a mangled filename doesn't crash the whole eval.
+
+    Intent-to-add staging picks up untracked files agents sometimes create
+    (new modules, fresh tests) so they show up in the diff instead of being
+    silently dropped.
+
+    @raises DiffCaptureError when the diff is empty (no changes — real
+            failure) or larger than MAX_DIFF_BYTES (scope pollution).
+    """
+    subprocess.run(
+        ["git", "add", "-A", "-N"],
+        cwd=str(repo_dir),
+        capture_output=True,
+        timeout=30,
+    )
+    result = subprocess.run(
+        ["git", "diff", base_commit, "HEAD"],
+        cwd=str(repo_dir),
+        capture_output=True,
+        timeout=60,
+    )
+    diff = result.stdout or b""
+
+    if len(diff) == 0:
+        raise DiffCaptureError(
+            f"capture_agent_diff: empty diff for {repo_dir} vs {base_commit[:12]}. "
+            f"The agent produced no changes against the base commit — real "
+            f"failure mode worth surfacing rather than shipping a zero-byte "
+            f"patch downstream."
+        )
+    if len(diff) > MAX_DIFF_BYTES:
+        raise DiffCaptureError(
+            f"capture_agent_diff: diff is {len(diff):,} bytes (> {MAX_DIFF_BYTES:,}). "
+            f"Intent-to-add scope is probably pulling in noise (build output, "
+            f"vendor dirs, upstream source re-emitted by the orchestrator's "
+            f"run tree). Refusing to hand this to the evaluator — it would "
+            f"fail to apply and burn real money."
+        )
+    return diff
+
+
+# ---------------------------------------------------------------------------
 # RC fixes — helper functions
 # ---------------------------------------------------------------------------
 

--- a/benchmarks/swe-bench/tests/test_capture_agent_diff.py
+++ b/benchmarks/swe-bench/tests/test_capture_agent_diff.py
@@ -1,0 +1,128 @@
+"""Regression tests for capture_agent_diff (defect d).
+
+Run:
+  python3 -m pytest benchmarks/swe-bench/tests/test_capture_agent_diff.py -v
+
+These are Python tests because the code under test is Python. They are NOT
+part of the mocha suite that runs in CI today — wire them into a pytest job
+when the SWE-bench container path is built out.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "run_swebench",
+    _HERE.parent / "evaluation-scripts" / "run_swebench.py",
+)
+_module = importlib.util.module_from_spec(_SPEC)
+try:
+    _SPEC.loader.exec_module(_module)  # type: ignore[union-attr]
+except Exception as exc:  # pragma: no cover - surfaces at collection time
+    pytest.skip(f"run_swebench.py did not import cleanly: {exc}", allow_module_level=True)
+
+capture_agent_diff = _module.capture_agent_diff
+DiffCaptureError = _module.DiffCaptureError
+
+
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def _git(cwd: Path, *args: str, input: bytes | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        env={**GIT_ENV},
+        input=input,
+        timeout=30,
+        check=False,
+    )
+
+
+def _seed_repo(tmp: Path) -> str:
+    _git(tmp, "init", "-q")
+    _git(tmp, "config", "user.email", "t@t")
+    _git(tmp, "config", "user.name", "t")
+    (tmp / "README.md").write_text("seed\n")
+    _git(tmp, "add", ".")
+    _git(tmp, "commit", "-m", "seed")
+    return _git(tmp, "rev-parse", "HEAD").stdout.decode().strip()
+
+
+def test_captures_bytes_even_when_file_content_contains_non_utf8():
+    """Regression: the diff contains a file whose bytes don't decode as
+    UTF-8. Previously `subprocess.run(..., text=True)` raised
+    UnicodeDecodeError; now returns bytes without touching the decoder.
+    """
+    with tempfile.TemporaryDirectory(prefix="cap-d-") as t:
+        tmp = Path(t)
+        base_sha = _seed_repo(tmp)
+
+        # Force git to treat the file as text so the diff body includes
+        # the raw bytes. Without .gitattributes git could mark it binary
+        # and emit only "Binary files a/x and b/x differ" — which is ASCII
+        # and wouldn't exercise the decoder path we're testing.
+        (tmp / ".gitattributes").write_text("notes.txt text\n")
+        bad = tmp / "notes.txt"
+        bad.write_bytes(b"hello\n\xd4\xe9\xa0 latin-1 residue\n")
+        _git(tmp, "add", ".")
+        _git(tmp, "commit", "-m", "add notes with non-utf8")
+
+        out = capture_agent_diff(tmp, base_sha)
+
+        assert isinstance(out, bytes), "must return bytes, not str"
+        assert b"notes.txt" in out, "diff should reference the file"
+        assert b"\xd4" in out, "raw non-UTF-8 byte should survive through the pipe"
+
+
+def test_empty_diff_raises_with_actionable_message():
+    """An empty diff means the agent made no changes. That's a real failure
+    mode (rollback, crash, bad plan) and the caller needs to know about it,
+    not silently receive zero bytes.
+    """
+    with tempfile.TemporaryDirectory(prefix="cap-empty-") as t:
+        tmp = Path(t)
+        base_sha = _seed_repo(tmp)
+
+        with pytest.raises(DiffCaptureError) as exc_info:
+            capture_agent_diff(tmp, base_sha)
+
+        msg = str(exc_info.value).lower()
+        assert "empty diff" in msg
+        assert base_sha[:12] in str(exc_info.value), "error should name the base commit"
+
+
+def test_oversized_diff_raises_before_shipping_to_container():
+    """A >10 MB diff almost always means the intent-to-add scope pulled in
+    noise (build output, vendor trees). Refuse to hand it downstream.
+    """
+    with tempfile.TemporaryDirectory(prefix="cap-huge-") as t:
+        tmp = Path(t)
+        base_sha = _seed_repo(tmp)
+
+        # ~14 MB of text — 8 bytes × 2M lines — easily clears the 10 MB gate.
+        huge = tmp / "src"
+        huge.mkdir()
+        (huge / "generated.py").write_text("# line\n" * 2_000_000)
+        _git(tmp, "add", ".")
+        _git(tmp, "commit", "-m", "generated blob")
+
+        with pytest.raises(DiffCaptureError) as exc_info:
+            capture_agent_diff(tmp, base_sha)
+
+        msg = str(exc_info.value)
+        assert "10,485,760" in msg, "error should name the ceiling"
+        assert "bytes" in msg.lower()


### PR DESCRIPTION
## Summary
Adds a bytes-safe diff-capture utility to `benchmarks/swe-bench/evaluation-scripts/run_swebench.py` that will become the input to the per-instance SWE-bench container path once that lands. Shipped on its own because it's independent of the pending design-review decisions on scope/plumbing, and because it has genuine regression coverage.

## Root cause
`subprocess.run(..., text=True)` around `git diff <base> HEAD` raised `UnicodeDecodeError` the moment the diff contained non-UTF-8 bytes. Happens on real SWE-bench workdirs for several reasons: filenames in legacy encodings, binary-file marker lines with byte-level metadata, and text files with non-UTF-8 content (latin-1 residue in older repos, test fixtures with arbitrary byte sequences). Surfaced during Phase 4a smoke runs, aborted evals before anything downstream saw the diff.

## Fix
- `capture_agent_diff` returns **bytes**. Callers decode at the point of use with `errors='replace'` so a mangled filename doesn't crash the whole eval.
- New `DiffCaptureError` class with size + empty-diff guardrails:
  - **Empty diff** → raise (the agent produced no changes — real failure, surface it instead of shipping zero bytes)
  - **>10 MB diff** → raise (scope pollution, would fail to apply and waste eval cycles)
- `MAX_DIFF_BYTES = 10 * 1024 * 1024` as a named constant.

## Regression tests (3)
`benchmarks/swe-bench/tests/test_capture_agent_diff.py`:
1. Non-UTF-8 file content survives capture without raising (uses `.gitattributes` `text` override so git emits the raw bytes in the diff body rather than a `Binary files differ` marker, which would be ASCII and not exercise the decoder path).
2. Empty diff raises `DiffCaptureError` with the base commit named in the message.
3. >10 MB diff raises `DiffCaptureError` with the ceiling named in the message.

Run: `python3 -m pytest benchmarks/swe-bench/tests/ -v` → 3 passed. Tests are independent of the mocha CI suite; a follow-up wires them into CI once the SWE-bench container path has a landed home.

## What's NOT in this PR
- **Intent-to-add scope fix (defect e).** Held back deliberately. Smoke3 showed pathspec excludes are a containment measure, not a fix — sympy's post-orchestrator workdir produced a 31.7 MB diff even with `runs/ node_modules/ .swarm/ plans/` excluded. The architecturally correct fix is manifest-driven (`session-state.json`'s per-step changed-files), not negative pathspecs. Tracked in the SWE-bench Phase 4a design-review issue.
- **Per-instance container test path.** Held back pending the same design review.

Net: this PR makes the diff-capture utility safe on main. Its downstream plumbing follows once the design review resolves.

## Test plan
- [x] `python3 -m pytest benchmarks/swe-bench/tests/ -v` → 3/3
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` unchanged (1446 passing)
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)