### PR TITLE
fix(planner): layer-split classifier input from agent guidance (#27 fix 1)

### DIFF
--- a/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
+++ b/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
@@ -314,19 +314,24 @@ def run_orchestrator(repo_dir: Path, problem_statement: str) -> dict:
         prompt_text = None  # Don't pipe via stdin for baseline
     else:
         # Full orchestrator pipeline.
-        # Prepend a constraint to avoid editing test files — SWE-bench applies
-        # a gold test patch after the agent runs, and edits to test files cause
-        # git-apply conflicts that always fail the evaluation.
-        goal_with_constraint = (
+        # The "do not edit tests" constraint goes through --agent-guidance, NOT
+        # --goal. --goal is the raw SWE-bench problem_statement; --agent-guidance
+        # is appended to each plan step's task by the orchestrator AFTER
+        # classification. Previously we concatenated the constraint into --goal,
+        # which poisoned the planner's classifier (the word "tests" in the
+        # constraint matched TesterElite's keyword patterns and the planner
+        # allocated a tester as primary agent for bug-fix tasks). See issue
+        # #27 Fix 1 / sympy__sympy-12481 smoke3 findings.
+        agent_guidance = (
             "IMPORTANT: Do NOT modify, delete, or rewrite any test files. "
             "Only edit source code to fix the issue. Test files are verified "
-            "by an external harness and your edits will cause patch conflicts.\n\n"
-            + problem_statement
+            "by an external harness and your edits will cause patch conflicts."
         )
         prompt_text = None
         cmd = [
             "node", str(SWARM_BIN), "run",
-            "--goal", goal_with_constraint,
+            "--goal", problem_statement,
+            "--agent-guidance", agent_guidance,
             "--tool", SWARM_TOOL,
             "--yes",
         ]

--- a/src/cli/swarm-handlers.ts
+++ b/src/cli/swarm-handlers.ts
@@ -660,7 +660,7 @@ export async function handleRunCommand(args: string[]): Promise<number> {
   const valuedFlags = new Set([
     '--model', '--resume', '--quality-gates-config', '--quality-gates-out',
     '--pr', '--target', '--dir', '--tool', '--team-size', '--max-premium-requests',
-    '--sarif', '--goal', '--base-commit',
+    '--sarif', '--goal', '--base-commit', '--agent-guidance',
   ]);
 
   // Extract positional tokens: skip the command name (args[0]) and any flag + value pairs
@@ -738,11 +738,25 @@ export async function handleRunCommand(args: string[]): Promise<number> {
   logger.info('🐝 Swarm Orchestrator - Plan & Execute\n');
   logger.info(`Goal: ${goal}\n`);
 
+  // --agent-guidance: text that the planner prepends to every step's task
+  // but does NOT feed into goal classification. Used by benchmark harnesses
+  // (e.g. run_swebench.py's "do not modify test files" constraint) so the
+  // guidance doesn't poison the classifier into picking the wrong agent.
+  // See issue #27 Fix 1.
+  const guidanceIndex = args.indexOf('--agent-guidance');
+  let agentGuidance = '';
+  if (guidanceIndex !== -1 && guidanceIndex + 1 < args.length) {
+    agentGuidance = args[guidanceIndex + 1];
+  }
+
   const configLoader = new ConfigLoader();
   const agents = configLoader.loadAllAgents();
   const generator = new PlanGenerator(agents);
   const usePlanCache = args.includes('--plan-cache');
-  const plan = generator.createPlan(goal, undefined, { planCache: usePlanCache });
+  const plan = generator.createPlan(goal, undefined, {
+    planCache: usePlanCache,
+    ...(agentGuidance ? { agentGuidance } : {}),
+  });
 
   const storage = new PlanStorage();
   const planFilename = storage.savePlan(plan);

--- a/src/plan-generator.ts
+++ b/src/plan-generator.ts
@@ -45,22 +45,51 @@ export class PlanGenerator {
    * Creates an execution plan from a high-level goal.
    * If userProvidedSteps is given, validates and uses them.
    * Otherwise, generates intelligent default steps based on goal analysis.
+   *
+   * **Layer boundary on `goal` vs `agentGuidance`.** The classifier
+   * (detectGoalType + assignAgent) uses ONLY the raw task intent. Callers
+   * that need to inject guidance the executing agent should see (e.g.
+   * "do not edit test files" constraints from a benchmark harness) pass
+   * that text through `options.agentGuidance` — it prepends to each
+   * step's task string so agents see it, but never reaches the
+   * classifier. This isolates goal-interpretation from agent-execution
+   * guidance; without the split, preamble text about "tests" or
+   * "security" misdirects the classifier into picking the wrong primary
+   * agent. See issue #27 (Fix 1) for the sympy-12481 failure mode this
+   * prevents.
    */
-  createPlan(goal: string, userProvidedSteps?: PlanStep[], options?: { planCache?: boolean }): ExecutionPlan {
+  createPlan(
+    goal: string,
+    userProvidedSteps?: PlanStep[],
+    options?: { planCache?: boolean; agentGuidance?: string },
+  ): ExecutionPlan {
     if (!goal || goal.trim() === '') {
       throw new Error('Goal cannot be empty');
     }
 
-    // plan cache: short-circuit if a similar plan already exists
+    // plan cache: short-circuit if a similar plan already exists. Cache key
+    // is the raw goal; agentGuidance doesn't affect step shape, only task
+    // text, and can be reapplied to a cached plan.
     if (options?.planCache && !userProvidedSteps) {
       const storage = new PlanStorage();
       const cached = storage.findCachedPlan(goal);
       if (cached) {
-        return { ...cached, goal: goal.trim(), createdAt: new Date().toISOString() };
+        const steps = options.agentGuidance
+          ? this.applyAgentGuidance(cached.steps, options.agentGuidance)
+          : cached.steps;
+        return {
+          ...cached,
+          goal: goal.trim(),
+          steps,
+          createdAt: new Date().toISOString(),
+        };
       }
     }
 
-    const steps = userProvidedSteps || this.generateIntelligentSteps(goal);
+    const rawSteps = userProvidedSteps || this.generateIntelligentSteps(goal);
+    const steps = options?.agentGuidance
+      ? this.applyAgentGuidance(rawSteps, options.agentGuidance)
+      : rawSteps;
 
     // validate that all assigned agents exist
     this.validateAgentAssignments(steps);
@@ -76,6 +105,20 @@ export class PlanGenerator {
         totalSteps: steps.length,
       }
     };
+  }
+
+  /**
+   * Prepend guidance text to every step's task so the executing agent sees
+   * it. Runs AFTER classification so the guidance never influences agent
+   * selection or step-shape decisions.
+   */
+  private applyAgentGuidance(steps: PlanStep[], guidance: string): PlanStep[] {
+    const trimmed = guidance.trim();
+    if (!trimmed) return steps;
+    return steps.map(step => ({
+      ...step,
+      task: `${trimmed}\n\n${step.task}`,
+    }));
   }
 
   /**

--- a/test/plan-generator.test.ts
+++ b/test/plan-generator.test.ts
@@ -388,4 +388,118 @@ describe('PlanGenerator', () => {
       assert.strictEqual(revised.metadata?.totalSteps, 2);
     });
   });
+
+  describe('classifier preamble hygiene (issue #27 fix 1)', () => {
+    // The exact goal text Phase 4a smoke3 used for sympy__sympy-12481.
+    // Reproducing it verbatim — any fuzzing risks changing the pattern match
+    // that poisoned the classifier.
+    const SYMPY_GOAL = [
+      '`Permutation` constructor fails with non-disjoint cycles',
+      'Calling `Permutation([[0,1],[0,1]])` raises a `ValueError` instead of',
+      'constructing the identity permutation. If the cycles passed in are',
+      'non-disjoint, they should be applied in left-to-right order and the',
+      'resulting permutation should be returned.',
+      '',
+      "This should be easy to compute. I don't see a reason why non-disjoint",
+      'cycles should be forbidden.',
+    ].join('\n');
+
+    const SWE_BENCH_PREAMBLE =
+      'IMPORTANT: Do NOT modify, delete, or rewrite any test files. ' +
+      'Only edit source code to fix the issue. Test files are verified ' +
+      'by an external harness and your edits will cause patch conflicts.';
+
+    it('LOCKS IN THE BUG: concatenated preamble+goal makes the classifier pick TesterElite', () => {
+      // This is the precondition test. If this test stops returning TesterElite,
+      // the classifier changed in a way that may have broken the mechanism this
+      // fix targets, and the positive-case test below becomes vacuous.
+      // The bug was: run_swebench.py concatenated the "do not edit tests"
+      // preamble onto the goal before passing it to --goal. The word "test"
+      // in the preamble matched assignAgent's TesterElite keyword regex.
+      const poisonedGoal = `${SWE_BENCH_PREAMBLE}\n\n${SYMPY_GOAL}`;
+      assert.strictEqual(
+        generator.assignAgent(poisonedGoal),
+        'TesterElite',
+        'precondition: without the layer split, preamble+goal returns TesterElite ' +
+          '(the classifier-poisoning mechanism this fix targets). If this stops ' +
+          'reproducing, the downstream test loses meaning.',
+      );
+    });
+
+    it('CAPTURES THE FIX: the raw task intent alone classifies away from TesterElite', () => {
+      // The mechanism of the fix: the classifier is called with the raw goal,
+      // not the preamble-wrapped goal. On the raw sympy intent, assignAgent
+      // must NOT return TesterElite — regardless of what specific agent it
+      // does pick (that's fix 2's territory; this test asserts the isolation
+      // property, not the correctness of the fallback).
+      const primary = generator.assignAgent(SYMPY_GOAL);
+      assert.notStrictEqual(
+        primary,
+        'TesterElite',
+        'raw bug-fix goal (no preamble) must not be classified as a testing task. ' +
+          `Got primary=${primary}.`,
+      );
+    });
+
+    it('createPlan with agentGuidance routes preamble to steps, not to classifier', () => {
+      // End-to-end: the layer split through createPlan. The classifier sees
+      // the raw goal (no preamble), so primary-agent selection is based on
+      // task intent. The preamble is still reachable by executing agents
+      // because it's prepended to every step's task text.
+      const plan = generator.createPlan(SYMPY_GOAL, undefined, {
+        agentGuidance: SWE_BENCH_PREAMBLE,
+      });
+      const primary = plan.steps[0].agentName;
+      assert.notStrictEqual(
+        primary,
+        'TesterElite',
+        'primary agent must not be TesterElite when guidance is routed via agentGuidance',
+      );
+      for (const step of plan.steps) {
+        assert.ok(
+          step.task.startsWith(SWE_BENCH_PREAMBLE),
+          'each step task must begin with the guidance so executing agents see it',
+        );
+      }
+      assert.strictEqual(
+        plan.goal,
+        SYMPY_GOAL,
+        'plan.goal records the raw task intent, unchanged by guidance',
+      );
+    });
+
+    it('createPlan without agentGuidance emits step tasks unchanged (backward compat)', () => {
+      const plan = generator.createPlan('Build a REST API');
+      for (const step of plan.steps) {
+        assert.ok(
+          !step.task.startsWith('IMPORTANT:'),
+          'no guidance → no preamble prepended to step tasks',
+        );
+      }
+    });
+
+    it('agentGuidance is layer-split even when userProvidedSteps is supplied', () => {
+      const userSteps: PlanStep[] = [
+        {
+          stepNumber: 1,
+          agentName: 'BackendMaster',
+          task: 'Implement the fix',
+          dependencies: [],
+          expectedOutputs: ['Fix'],
+        },
+      ];
+      const plan = generator.createPlan(SYMPY_GOAL, userSteps, {
+        agentGuidance: SWE_BENCH_PREAMBLE,
+      });
+      assert.strictEqual(
+        plan.steps[0].agentName,
+        'BackendMaster',
+        'explicit userProvidedSteps survives guidance injection',
+      );
+      assert.ok(
+        plan.steps[0].task.startsWith(SWE_BENCH_PREAMBLE),
+        'guidance still prepends to user-provided step tasks',
+      );
+    });
+  });
 });


### PR DESCRIPTION
Implements **Fix 1** from #27: preamble hygiene in the plan-generator's classifier.

## Root cause
`run_swebench.py`'s orchestrator path concatenated a "do not modify test files" preamble onto the SWE-bench `problem_statement` before passing it to `--goal`. The orchestrator's planner uses the `--goal` string as input to its classifier (`detectGoalType` + `assignAgent`). `assignAgent`'s TesterElite keyword regex matched the word "tests" in the preamble and allocated TesterElite as the primary agent for a bug-fix task. The preamble — whose purpose was preventing the agent from editing tests — poisoned the classifier into picking a test-writing agent.

Observed in Phase 4a smoke3 on `sympy__sympy-12481`: plan produced TesterElite × 2 + integrator_finalizer × 2, zero impl-editing steps.

## Survey result (per #27 halt-and-report condition)
Audited every goal/preamble concatenation path. **One site** only: `run_swebench.py:320` (pre-fix). The baseline path bypasses the planner. `run_fresh.sh` passes prompts verbatim. Internal orchestrator code (`mcp-server`, `swarm-handlers`, `plan-handlers`, `bootstrap-orchestrator`) never concatenates. Halt condition (>1 sites) not triggered.

Chose **Option B** (architectural layer split via `agentGuidance`) over Option A (strip preambles heuristically at the classifier) even with one current site:
- API surface is one optional param
- future benchmarks can't re-introduce the bug without opting in
- heuristic stripping is brittle on prompt variation

## Fix
`createPlan` gains an optional `agentGuidance` field:
```ts
generator.createPlan(goal, steps, { agentGuidance: PREAMBLE })
```
Classifier uses only `goal`. `agentGuidance` is prepended to every step's task string **after** classification, so executing agents still see the guidance but goal interpretation and agent selection happen on the task intent alone.

Wired through the CLI as `--agent-guidance`. `run_swebench.py` updates to pass `--goal problem_statement` plus `--agent-guidance PREAMBLE` separately instead of concatenating.

## Which of the other two fixes this does NOT address
- **Fix 2 (bug-fix goal type)**: sympy-12481's goal still falls to `'generic'` because no domain regex matches "Permutation" / "constructor" / "cycles". After fix 1, the primary agent becomes whatever `assignAgent`'s keyword fallback selects — observed in testing: `IntegratorFinalizer`, which is its own problem. Fix 2 adds a proper bug-fix goal type + BackendMaster-first template. That's the next PR.
- **Fix 3 (contract-change-aware template)**: contract-change-then-client from PR #22's pilot is still broken because the rigid library template puts impl before test-update. Fix 3 adds an aware template or verifier sequencing. Deferred behind fix 2.

## Regression tests (5 in `test/plan-generator.test.ts`)
Specifically designed to **capture the classifier-poisoning mechanism**, not just the symptom:

1. **LOCKS IN THE BUG** — concatenated `preamble + goal` classifies as TesterElite. This is the precondition assertion: if this stops reproducing, the fix's positive test below loses meaning, and the test file tells you immediately.
2. **CAPTURES THE FIX** — raw sympy goal alone does NOT classify as TesterElite. Assertion is negation (`notStrictEqual`), not a specific agent, because fix 2 will settle which agent is correct. This keeps the test robust to fix-2 tuning.
3. `createPlan` with `agentGuidance`: primary agent is not TesterElite, every step task begins with guidance so executing agents see it, `plan.goal` is the unchanged raw goal.
4. `createPlan` without `agentGuidance`: step tasks unchanged (backward compat).
5. `agentGuidance` is layer-split even when `userProvidedSteps` is passed.

## Verification
- `npm run typecheck` clean
- `npm run lint` clean  
- `npm test`: **1446 → 1451 passing**, 0 regressions

## Test plan
- [x] classifier-poisoning precondition still reproduces
- [x] fix captured at the mechanism level, not the symptom
- [x] CLI flag plumbed end-to-end
- [x] run_swebench.py updated to use separated fields
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)