### PR TITLE
feat(planner): contract-change goal type, bundled impl+callers+tests (#27 fix 3)

### DIFF
--- a/src/plan-generator.ts
+++ b/src/plan-generator.ts
@@ -524,16 +524,33 @@ OUTPUT ONLY THE JSON, NOTHING ELSE.`;
   }
 
   private detectGoalType(goal: string): GoalType {
+    // CLASSIFIER DISPATCH ORDER — do not reorder without re-reading this.
+    //
+    // Structural discriminators (contract-change, bug-fix) run BEFORE the
+    // keyword-based domain classifiers (api, library, frontend, etc.).
+    // Domain keywords are commonly present in goals that are actually
+    // coordinated-change or bug-report tasks — "update the `foo` library
+    // to ..." mentions "library" but should never route to the rigid
+    // library template because its step shape is wrong for a contract
+    // change. Centralizing the structural discrimination at the top of
+    // the chain means the decision lives in one place, audit-able and
+    // non-duplicated across templates. See #27 Fixes 2 and 3 for the
+    // two failure modes the ordering prevents.
+    //
+    // Precedence when a goal has BOTH structural shapes (≥2 backticks +
+    // failure verb AND ≥2 change verbs — e.g., "fix this: update foo,
+    // rename bar, modify baz"): contract-change wins because it runs
+    // first. That's the intended precedence — a goal with multi-target
+    // imperative change verbs is better served by the bundled impl+tests
+    // shape than by the bug-fix 3-step shape, even when it opens with a
+    // failure description. If a counter-example surfaces where this
+    // precedence produces the wrong plan shape, that's the evidence to
+    // revisit here.
     const goalLower = goal.toLowerCase();
 
     // contract-change: coordinated modification of existing code (impl +
     // callers + tests). Must run BEFORE the domain classifiers (api, library,
-    // etc.) because a contract-change goal often mentions the domain as
-    // context ("update the `foo` library to make X required") — if we
-    // classified it as 'library' first, the rigid library template would
-    // put impl in step 1 and tests in step 2, and step 1's verifier would
-    // catch failing-but-about-to-be-updated tests and roll back. See #27
-    // Fix 3 (contract-change-then-client-001 failure mode from PR #22).
+    // etc.) — see ordering note above.
     if (this.hasContractChangeShape(goal)) {
       return 'contract-change';
     }
@@ -1042,10 +1059,13 @@ OUTPUT ONLY THE JSON, NOTHING ELSE.`;
         agentName: 'BackendMaster',
         task:
           `Apply the following contract change as a single atomic step. ` +
-          `Land the impl change, every caller update, and the corresponding ` +
-          `test updates in this step — the verifier runs tests against the ` +
-          `combined state, and splitting the change across steps will cause ` +
-          `mid-plan test failures and rollback.\n\n` +
+          `This step must update the implementation, every call site, AND ` +
+          `every affected test so the test suite passes against the new ` +
+          `contract when the step completes. Updating impl + callers while ` +
+          `leaving pre-existing tests unchanged is a failure mode of this ` +
+          `step: pre-existing tests assert the OLD contract and will fail ` +
+          `verification against the NEW impl. Updating tests is not ` +
+          `optional; it is part of the atomic bundle.\n\n` +
           `Contract change:\n${goal}\n\n` +
           `Acceptance criteria:\n${criteria}`,
         dependencies: [],

--- a/src/plan-generator.ts
+++ b/src/plan-generator.ts
@@ -32,7 +32,7 @@ export interface ReplanPayload {
   addSteps?: { agent: string; task: string; afterStep?: number }[];
 }
 
-export type GoalType = 'api' | 'web-app' | 'cli-tool' | 'library' | 'infrastructure' | 'data-pipeline' | 'mobile-app' | 'bug-fix' | 'generic';
+export type GoalType = 'api' | 'web-app' | 'cli-tool' | 'library' | 'infrastructure' | 'data-pipeline' | 'mobile-app' | 'bug-fix' | 'contract-change' | 'generic';
 
 export class PlanGenerator {
   private gateConfig: QualityGatesConfig | undefined;
@@ -364,6 +364,12 @@ OUTPUT ONLY THE JSON, NOTHING ELSE.`;
         'Preserve observable behavior for every code path the fix does not target. A bug fix that changes behavior elsewhere is a regression.',
         'Error messages and exception types must match what downstream callers already depend on, unless the issue explicitly asks to change them.',
       ],
+      'contract-change': [
+        'Apply the contract change and every caller/test update in this single step. The post-step verifier runs tests against the combined state — an impl change without its matching test updates will fail verification and force a rollback.',
+        'Enumerate every call site before editing. A caller the agent missed is a broken build; use the repo\'s own tools (grep, TypeScript references) to find them all.',
+        'Update tests alongside the impl so existing tests that exercised the pre-change contract become tests of the post-change contract. Adding entirely new tests is fine; leaving stale tests in place is not.',
+        'Do not introduce unrelated refactors while touching each file. The only changes that belong in this step are the ones the contract change requires.',
+      ],
     };
 
     const criteria = [...shared, ...(byType[goalType] || [])];
@@ -436,20 +442,28 @@ OUTPUT ONLY THE JSON, NOTHING ELSE.`;
         steps.push(...this.generateBugFixSteps(goal, stepNumber));
         break;
 
+      case 'contract-change':
+        steps.push(...this.generateContractChangeSteps(goal, stepNumber));
+        break;
+
       default:
         steps.push(...this.generateGenericSteps(goal, stepNumber));
     }
 
-    this.applyGateRequirements(steps, goal);
+    this.applyGateRequirements(steps, goal, goalType);
 
     return steps;
   }
 
   /**
    * Append gate-derived requirements to step prompts when gate config is available.
-   * Also injects a test step if testCoverage is enabled and no TesterElite step exists.
+   * Also injects a test step if testCoverage is enabled and no TesterElite step exists —
+   * EXCEPT for contract-change plans, where tests are updated in the same step as the
+   * impl change by template design (see generateContractChangeSteps). Injecting a
+   * separate TesterElite step on a contract-change plan would re-introduce the exact
+   * impl-vs-test split that #27 Fix 3 exists to prevent.
    */
-  private applyGateRequirements(steps: PlanStep[], goal: string): void {
+  private applyGateRequirements(steps: PlanStep[], goal: string, goalType?: GoalType): void {
     if (!this.gateConfig) return;
 
     for (const step of steps) {
@@ -459,7 +473,12 @@ OUTPUT ONLY THE JSON, NOTHING ELSE.`;
       }
     }
 
-    // Inject a test step when testCoverage is enabled and no test step exists
+    // Inject a test step when testCoverage is enabled and no test step exists.
+    // Contract-change plans bundle tests into their impl step; a separate
+    // TesterElite step here would re-create the broken mid-plan `npm test`
+    // against a half-updated state.
+    if (goalType === 'contract-change') return;
+
     if (requiresTestStep(this.gateConfig)) {
       const hasTestStep = steps.some(s => s.agentName === 'TesterElite');
       if (!hasTestStep) {
@@ -506,6 +525,18 @@ OUTPUT ONLY THE JSON, NOTHING ELSE.`;
 
   private detectGoalType(goal: string): GoalType {
     const goalLower = goal.toLowerCase();
+
+    // contract-change: coordinated modification of existing code (impl +
+    // callers + tests). Must run BEFORE the domain classifiers (api, library,
+    // etc.) because a contract-change goal often mentions the domain as
+    // context ("update the `foo` library to make X required") — if we
+    // classified it as 'library' first, the rigid library template would
+    // put impl in step 1 and tests in step 2, and step 1's verifier would
+    // catch failing-but-about-to-be-updated tests and roll back. See #27
+    // Fix 3 (contract-change-then-client-001 failure mode from PR #22).
+    if (this.hasContractChangeShape(goal)) {
+      return 'contract-change';
+    }
 
     if (goalLower.match(/\b(rest|api|endpoint|graphql|microservice|backend|server)\b/)) {
       return 'api';
@@ -557,6 +588,43 @@ OUTPUT ONLY THE JSON, NOTHING ELSE.`;
     }
 
     return 'generic';
+  }
+
+  /**
+   * Structural discriminator for contract-change goals: coordinated
+   * modifications to existing code across impl + callers + tests, with
+   * explicit "update X, update Y" language. Two signals required:
+   *   1. At least two backtick-wrapped code references (existing symbols,
+   *      files, or APIs the task names). Same floor as hasBugReportShape
+   *      to keep the greenfield false-positive rate low.
+   *   2. At least two imperative change verbs — "update X" / "rename X" /
+   *      "modify X" / "change X" — which signals the author expects work
+   *      distributed across multiple artifacts rather than a single new
+   *      build.
+   *
+   * The second signal is what distinguishes contract-change from bug-fix:
+   * bug-fix describes OBSERVED failure; contract-change prescribes
+   * INTENDED multi-artifact change. Both can match the same existing code
+   * backtick-density signal, but only one uses multi-target update verbs.
+   *
+   * Kept deliberately narrow. A single "update X" clause isn't enough —
+   * "fix this: update index.js" is closer to bug-fix shape. Two separate
+   * update clauses ("update X ... update Y") is what marks the
+   * coordinated-change intent that the contract-change template exists
+   * to handle.
+   *
+   * See issue #27 Fix 3.
+   */
+  private hasContractChangeShape(goal: string): boolean {
+    const backtickMatches = goal.match(/`[^`\n]+`/g) ?? [];
+    if (backtickMatches.length < 2) return false;
+
+    // Count distinct imperative change clauses. `\b(update|rename|...)\s+\S+`
+    // matches "update X" / "rename X" etc.; we require ≥2 so a lone
+    // "update index.js" in a bug-fix description doesn't misroute.
+    const changeVerbRe = /\b(update|rename|modify|change|convert)\s+[^\s.,;]+/gi;
+    const verbCount = (goal.match(changeVerbRe) ?? []).length;
+    return verbCount >= 2;
   }
 
   /**
@@ -931,6 +999,75 @@ OUTPUT ONLY THE JSON, NOTHING ELSE.`;
         expectedOutputs: [
           'Scope review notes',
           'Documentation updates if public surface changed',
+          'Quality review notes',
+        ],
+      },
+    ];
+  }
+
+  /**
+   * Template for coordinated modifications to an existing codebase — the
+   * "contract change" shape. Structural invariant of this template:
+   *
+   *   The impl change, the caller updates, and the test updates all land
+   *   in ONE step. There is NO separate TesterElite-owned test-update step
+   *   between impl-change and IntegratorFinalizer.
+   *
+   * Rationale (#27 Fix 3 root-cause analysis). The library template and
+   * bug-fix template both place BackendMaster → TesterElite as two
+   * separate steps. Between them, the per-step verifier runs `npm test`.
+   * For a contract-change task, step 1 lands the impl change that
+   * intentionally breaks the pre-existing tests (they assert the OLD
+   * contract); `npm test` fails; verifier rolls step 1 back; step 2
+   * never runs. This template removes that failure mode by bundling
+   * impl + callers + tests into one step whose post-step verification
+   * sees a coherent post-contract-change state.
+   *
+   * Verifier contract is unchanged. The orchestrator's per-step
+   * verification discipline is what catches agent lies; weakening it to
+   * "defer `npm test` to end-of-plan" would defeat that discipline. The
+   * plan generator's job is to shape plans the per-step verifier can
+   * successfully evaluate.
+   *
+   * Why only 2 steps. For a bundled change, there's no coherent handoff
+   * to a second impl-editing step. IntegratorFinalizer stays as the
+   * scope/quality reviewer.
+   */
+  private generateContractChangeSteps(goal: string, startNumber: number): PlanStep[] {
+    const criteria = this.getAcceptanceCriteria('contract-change');
+    const reviewCriteria = this.getIntegratorReviewCriteria();
+    return [
+      {
+        stepNumber: startNumber,
+        agentName: 'BackendMaster',
+        task:
+          `Apply the following contract change as a single atomic step. ` +
+          `Land the impl change, every caller update, and the corresponding ` +
+          `test updates in this step — the verifier runs tests against the ` +
+          `combined state, and splitting the change across steps will cause ` +
+          `mid-plan test failures and rollback.\n\n` +
+          `Contract change:\n${goal}\n\n` +
+          `Acceptance criteria:\n${criteria}`,
+        dependencies: [],
+        expectedOutputs: [
+          'Updated implementation',
+          'All call sites updated',
+          'Tests updated to exercise the post-change contract',
+          'Docs/examples updated where the contract surfaces publicly',
+        ],
+      },
+      {
+        stepNumber: startNumber + 1,
+        agentName: 'IntegratorFinalizer',
+        task:
+          `Review the contract change's scope, quality, and documentation. ` +
+          `Confirm every call site was updated (no stale pre-change callers) ` +
+          `and the test suite now exercises the post-change contract rather ` +
+          `than asserting on the old one.\n\n${reviewCriteria}`,
+        dependencies: [startNumber],
+        expectedOutputs: [
+          'Scope review notes',
+          'Caller-update completeness check',
           'Quality review notes',
         ],
       },

--- a/test/plan-generator.test.ts
+++ b/test/plan-generator.test.ts
@@ -594,6 +594,188 @@ describe('PlanGenerator', () => {
     }
   });
 
+  describe('contract-change goal type (issue #27 fix 3)', () => {
+    // The exact PR #22 pilot goal that produced the broken shape: simple-get's
+    // userAgent-required contract change. Pre-Fix-3, this classified as
+    // 'library' and the rigid library template put impl in step 1 with tests
+    // in step 2 — step 1's verifier ran npm test against pre-existing tests
+    // that expected the old contract, failed, rolled back, step 2 never ran.
+    const SIMPLE_GET_GOAL =
+      '`simple-get` is an HTTP client library with an options object. ' +
+      'Make the `userAgent` string a required option: the module must throw ' +
+      "`Error('simple-get: userAgent option is required')` when it is missing " +
+      'from a call. Update `index.js` (the main entry point), update the ' +
+      "TypeScript types if present, update README.md's examples to supply " +
+      '`userAgent`, and update the existing test file so every call passes ' +
+      "`userAgent: 'simple-get-test'` or similar. Do not weaken the check to " +
+      "'warn' — it must throw.";
+
+    const RENAME_CALLERS_GOAL =
+      'Rename the default-exported function currently named `isPlainObject` ' +
+      'to `isPureObject`. Update every call site in the repo, update the test ' +
+      'file, update the TypeScript type definitions, and update every ' +
+      'reference in README.md.';
+
+    const SCHEMA_UPDATE_GOAL =
+      'Add a `publishedAt DateTime?` field to the `Post` model in ' +
+      '`prisma/schema.prisma`. Update the migration file and update ' +
+      '`src/index.ts` so one of the demo queries filters posts on ' +
+      '`publishedAt`.';
+
+    // Direct classifier tests — tied to classifyGoal, not plan shape,
+    // so they keep signaling if future tuning breaks the contract.
+    it('classifyGoal(simple-get contract change) === "contract-change"', () => {
+      assert.strictEqual(generator.classifyGoal(SIMPLE_GET_GOAL), 'contract-change');
+    });
+
+    it('classifyGoal(rename-then-update-callers) === "contract-change"', () => {
+      assert.strictEqual(generator.classifyGoal(RENAME_CALLERS_GOAL), 'contract-change');
+    });
+
+    it('classifyGoal(schema-then-query update) === "contract-change"', () => {
+      assert.strictEqual(generator.classifyGoal(SCHEMA_UPDATE_GOAL), 'contract-change');
+    });
+
+    // False-positive guardrails
+    it('greenfield "update docs" without multi-target updates does NOT trip contract-change', () => {
+      // Single "update" clause, greenfield otherwise — not a contract change.
+      assert.notStrictEqual(
+        generator.classifyGoal(
+          'Build a new documentation site and update the README to describe it',
+        ),
+        'contract-change',
+      );
+    });
+
+    it('bug-fix description with one "update" clause does NOT trip contract-change', () => {
+      // Bug report with a single "update" in the proposed work doesn't become
+      // contract-change — only multi-target update clauses do.
+      const bugWithUpdate =
+        '`parse()` raises `TypeError` when given None. Update `parse()` to ' +
+        'return an empty result for None inputs.';
+      assert.notStrictEqual(generator.classifyGoal(bugWithUpdate), 'contract-change');
+    });
+
+    it('backtick-free multi-update goal does NOT trip contract-change', () => {
+      // Without backtick refs to existing symbols, a greenfield multi-part
+      // build ("update the backend ... update the frontend") shouldn't route
+      // to contract-change. It'd be a multi-module new-build, not a
+      // coordinated-change-to-existing.
+      assert.notStrictEqual(
+        generator.classifyGoal(
+          'Build and deploy. Update the backend configs, update the frontend ' +
+            'build, update the documentation.',
+        ),
+        'contract-change',
+      );
+    });
+
+    // Template shape invariants — the heart of Fix 3
+    const IMPL_EDITING_AGENTS = new Set(['BackendMaster', 'FrontendExpert']);
+
+    it('plan has no impl→test-update split: there is never a TesterElite step between an impl step and IntegratorFinalizer', () => {
+      // The exact observed broken shape from smoke3 / PR #22 pilot was
+      // BackendMaster (impl) → TesterElite (test update) — with the verifier
+      // running `npm test` between them against a half-updated codebase.
+      // The contract-change template must NOT produce that sequence.
+      const plan = generator.createPlan(SIMPLE_GET_GOAL);
+      for (let i = 0; i < plan.steps.length - 1; i++) {
+        const here = plan.steps[i];
+        const next = plan.steps[i + 1];
+        if (IMPL_EDITING_AGENTS.has(here.agentName) && next.agentName === 'TesterElite') {
+          assert.fail(
+            `step ${here.stepNumber} (${here.agentName}) is followed by a ` +
+              `separate TesterElite step. That's the broken shape: ` +
+              `per-step verification will run tests against a half-applied ` +
+              `contract change and roll back. See #27 Fix 3.`,
+          );
+        }
+      }
+    });
+
+    it('the single impl step bundles impl + callers + tests (task prompt mentions all three)', () => {
+      const plan = generator.createPlan(SIMPLE_GET_GOAL);
+      const implStep = plan.steps.find(s => IMPL_EDITING_AGENTS.has(s.agentName));
+      assert.ok(implStep, 'plan must contain an impl-editing step');
+      const task = implStep!.task.toLowerCase();
+      // The task prompt must make the bundle explicit — otherwise the agent
+      // might ship impl alone and call it done.
+      assert.ok(
+        task.includes('caller') || task.includes('call site'),
+        'task prompt must direct the agent to update call sites',
+      );
+      assert.ok(
+        task.includes('test'),
+        'task prompt must direct the agent to update tests in the same step',
+      );
+      assert.ok(
+        task.includes('atomic') || task.includes('single') || task.includes('combined'),
+        'task prompt must signal single-step atomicity of the bundle',
+      );
+    });
+
+    it('exactly one impl-editing step, so there is nothing after it for npm test to trip on', () => {
+      const plan = generator.createPlan(SIMPLE_GET_GOAL);
+      const implSteps = plan.steps.filter(s => IMPL_EDITING_AGENTS.has(s.agentName));
+      assert.strictEqual(
+        implSteps.length,
+        1,
+        `contract-change plans bundle all editing into one step. Got ` +
+          `${implSteps.length} impl-editing steps: ` +
+          `${implSteps.map(s => `${s.stepNumber}:${s.agentName}`).join(', ')}`,
+      );
+    });
+
+    it('plan does NOT contain a TesterElite step at all for contract-change', () => {
+      // TesterElite writes tests as a separate step. For contract-change,
+      // the impl step updates the tests in-place; a TesterElite step after
+      // would be redundant OR reintroduce the impl/test split.
+      const plan = generator.createPlan(SIMPLE_GET_GOAL);
+      const testerSteps = plan.steps.filter(s => s.agentName === 'TesterElite');
+      assert.strictEqual(
+        testerSteps.length,
+        0,
+        'contract-change template must not allocate TesterElite as its own step',
+      );
+    });
+
+    it('greenfield library goal still routes to the library template (no regression)', () => {
+      // Classifying "contract-change" before "library" is correct only if the
+      // contract-change discriminator is strict enough that greenfield library
+      // builds still reach the library template.
+      const plan = generator.createPlan(
+        'Build a small utility library for date formatting with date, time, and timezone helpers',
+      );
+      // library template is 3 steps; contract-change is 2
+      assert.notStrictEqual(
+        plan.steps.length,
+        2,
+        'greenfield library should not route to the 2-step contract-change template',
+      );
+    });
+
+    it('applyGateRequirements with testCoverage enabled does NOT re-inject TesterElite on contract-change plans', () => {
+      // Production configs load gate configs with testCoverage: enabled. Before
+      // the applyGateRequirements guard, the auto-inject path would add a
+      // TesterElite step to any plan missing one — re-creating the exact
+      // impl→test-update split Fix 3 prevents.
+      const { DEFAULT_QUALITY_GATES_CONFIG } = require('../src/quality-gates/default-config');
+      const configLoader = new ConfigLoader();
+      const agents = configLoader.loadAllAgents();
+      const gatedGenerator = new PlanGenerator(agents, DEFAULT_QUALITY_GATES_CONFIG);
+
+      const plan = gatedGenerator.createPlan(SIMPLE_GET_GOAL);
+      const testerSteps = plan.steps.filter(s => s.agentName === 'TesterElite');
+      assert.strictEqual(
+        testerSteps.length,
+        0,
+        'contract-change plan must stay free of TesterElite even with ' +
+          'testCoverage gate enabled; found: ' +
+          testerSteps.map(s => `step ${s.stepNumber}`).join(', '),
+      );
+    });
+  });
+
   describe('bug-fix goal type (issue #27 fix 2)', () => {
     // Representative bug-report-shaped goals sourced from real SWE-bench
     // Verified instance bodies. Kept small: the discriminator's behavior


### PR DESCRIPTION
Implements **Fix 3** from #27: a `contract-change` goal type whose template produces plans with no impl→test-update split.

## Halt-check answers
- **Step model supports multi-file atomic changes?** Yes. A step gives an agent full-repo access; the verifier runs post-step on the combined state. No "one step = one concern" constraint exists to block bundling. Halt not triggered; proceeded.
- **Agent roster covers the template?** Yes. BackendMaster (bundled editor) + IntegratorFinalizer (review). No new agent needed.

## Root cause (from #27 investigation)
PR #22 pilot's `contract-change-then-client-001`: rigid `library` template hardcoded BackendMaster → TesterElite as two separate steps. Step 1 lands the impl change that intentionally breaks pre-existing tests (they assert the OLD contract), verifier runs `npm test`, tests fail, rolls step 1 back, step 2 never runs.

## Fix: planner-side (not verifier-side)
Per your #27 guidance: fixing this by "defer `npm test` to end-of-plan" in the verifier would defeat per-step verification (how the orchestrator catches agent lies). The plan-shape decision belongs in the planner.

## Discriminator (`hasContractChangeShape`)
Two signals both required:
1. ≥2 backtick-wrapped code references (same floor as bug-fix)
2. ≥2 imperative change verbs — `update X` / `rename X` / `modify X` / `change X` / `convert X` — targeting distinct artifacts

Signal 2 distinguishes contract-change from bug-fix: bug-fix describes **observed failure**, contract-change prescribes **intended multi-artifact change**. Ordered before the domain classifiers (library/api/etc.) because contract-change goals often mention the domain as context ("update the `foo` library to make X required").

## Template (`generateContractChangeSteps`)
Exactly TWO steps:
1. **BackendMaster** — bundled impl + callers + tests + docs. Task prompt explicitly signals atomicity of the bundle.
2. **IntegratorFinalizer** — scope and quality review.

No separate TesterElite step. Post-step verifier sees a coherent post-contract-change state.

## Gate-config guard
Production gate configs enable `testCoverage` by default, which auto-injects a TesterElite step when none exists — reintroducing the broken shape. `applyGateRequirements` now skips the injection when `goalType === 'contract-change'`, with a regression test exercising `DEFAULT_QUALITY_GATES_CONFIG` to lock it in.

## Regression tests (12)
- Direct classifier: 3 contract-change positives (simple-get, rename-then-update-callers, schema-then-query)
- 3 false-positive guardrails: greenfield with single "update docs", bug-fix with one "update" clause, backtick-free multi-update build
- 5 template shape invariants: no impl→TesterElite adjacency, bundle-mention in task prompt, exactly one impl step, no TesterElite step at all, greenfield library still routes to library template
- 1 gate-config regression: `DEFAULT_QUALITY_GATES_CONFIG` loaded, contract-change plan still has zero TesterElite steps

## Verification
- `npm run typecheck` clean
- `npm run lint` clean
- `npm test`: **1471 → 1483 passing**, 0 regressions

## Design points for review
1. **Discriminator signal 2: ≥2 change verbs required, not ≥1.** A single "update X" in a bug report would misroute with ≥1. My ≥2 regression test ("bug-fix description with one 'update' clause") locks this in. If you see a real contract-change goal with only one "update" clause, that's evidence to loosen.
2. **Classifier priority: contract-change before domain classifiers.** Required because a contract-change goal mentioning "library" would otherwise route to the library template. Ordered just after the other structural discriminators but before the keyword-based domain classifiers.
3. **Template has no TesterElite step at all.** The impl step's prompt directs the agent to update tests in-place. If you prefer a separate-but-dependent TesterElite step that runs AFTER impl but BEFORE verifier-runs-npm-test (which would require relaxing the per-step verifier), that's a different shape — flag if so; I stuck with pure bundling because it's the cleanest way to keep per-step verification intact.

## What unblocks after this lands (per #27 queue)
- **Issue 2 (manifest-driven intent-to-add)** — unblocks. Next work item toward Phase 4a.
- **Phase 3b (constraint-binding expansion)** — unblocks (Fix 1 + Fix 3 both needed; Fix 2 helpful but not blocking).
- **Phase 4a smoke4** — still blocked on Issue 2.

## Test plan
- [x] Contract-change invariant holds on 3 real PR-#22 / constraint-binding-shaped goals
- [x] Discriminator rejects 3 false-positive shapes
- [x] No impl→test-update split in any contract-change plan
- [x] Gate-config auto-injection does not re-introduce the broken shape
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)