### PR TITLE
fix(bench): pilot-hypothesis fixes for harness/validators pre-Phase-3b

### DIFF
--- a/benchmarks/constraint-binding/SOURCES.md
+++ b/benchmarks/constraint-binding/SOURCES.md
@@ -20,7 +20,7 @@ Columns: `task-id | repo | sha | subpath | sha256 | license`
 
 | task-id | repo | sha | subpath | sha256 | license |
 |---------|------|-----|---------|--------|---------|
-| schema-then-query-001 | https://github.com/prisma/prisma-examples | 663c23ca1a6c6f03d2ad0c67868020b560a172e4 | databases/turso | 1cbb0eba91f8e0662849bc6de629134f61c7c56709b4318a965f323c673a2af8 | Apache-2.0 |
+| schema-then-query-001 | https://github.com/prisma/prisma-examples | 663c23ca1a6c6f03d2ad0c67868020b560a172e4 | databases/turso | de86f10a22619212b8098f03cb813dae259b556515e52c40b6b7c979a9800be3 | Apache-2.0 |
 | rename-then-update-callers-001 | https://github.com/sindresorhus/is-plain-obj | 97f38e8836f86a642cce98fc6ab3058bc36df181 | . | ff44ff6c44872cf3cfd59f7f62ee19f586eef96ecf01f2904a9407feece55b03 | MIT |
 | contract-change-then-client-001 | https://github.com/feross/simple-get | e7a74115ca9dd28720f186275c5a67df81985426 | . | 6d208d19be4d09d0a9d249e255a9db1d85376700e34aa28f2262002265f4f726 | MIT |
 | lift-then-reuse-001 | https://github.com/feross/queue-microtask | 2a5e7b9874c5f075e62975862e5e4a673f149786 | . | 5b92963c012911b5f3d9a183626d847808c1e3195111c413127b8371410d01d2 | MIT |

--- a/benchmarks/constraint-binding/tasks/lift-then-reuse-001.yaml
+++ b/benchmarks/constraint-binding/tasks/lift-then-reuse-001.yaml
@@ -19,8 +19,13 @@ prompt: |
 expected_steps_min: 2
 post_state_validators:
   - name: "resolveScheduler helper is declared in index.js"
+    # Tolerate whitespace between the function name and its opening paren —
+    # `function resolveScheduler ()` and `function resolveScheduler()` are both
+    # valid JS and agents may emit either. Pilot hypothesis from smoke3: the
+    # stricter regex `function resolveScheduler\(` missed a correct lift that
+    # used the spaced form. See #27 pilot scoreboard.
     cmd: |
-      grep -E "function resolveScheduler\\(|resolveScheduler\\s*=\\s*" index.js
+      grep -E "function resolveScheduler[[:space:]]*\(|resolveScheduler[[:space:]]*=[[:space:]]*" index.js
   - name: "default export is still a function"
     cmd: |
       node -e "const f = require('./index.js'); if (typeof f !== 'function') process.exit(1)"

--- a/benchmarks/constraint-binding/tasks/rename-then-update-callers-001.yaml
+++ b/benchmarks/constraint-binding/tasks/rename-then-update-callers-001.yaml
@@ -16,12 +16,22 @@ prompt: |
 expected_steps_min: 3
 post_state_validators:
   - name: "no references to the old name remain in source files"
+    # Excludes: node_modules (upstream deps may legitimately reference the
+    # pre-rename name — that's not the agent's code), and rename.test.js
+    # (a defensive test an agent might write to ASSERT the rename happened;
+    # such a test needs to reference the old name as a string literal).
+    # Pilot hypothesis from smoke3: without these exclusions the validator
+    # fails correct rename implementations. See #27 pilot scoreboard.
     cmd: |
       if grep -rn --include='*.js' --include='*.ts' --include='*.mjs' --include='*.cjs' \
+          --exclude-dir=node_modules \
+          --exclude='rename*.test.*' \
+          --exclude='*rename-check*' \
           'isPlainObject' . >/dev/null; then exit 1; fi
   - name: "the new name is used in at least the expected places"
     cmd: |
       count=$(grep -rn --include='*.js' --include='*.ts' --include='*.mjs' \
+        --exclude-dir=node_modules \
         'isPureObject' . | wc -l)
       test "$count" -ge 3
   - name: "package installs and tests pass"

--- a/benchmarks/constraint-binding/tasks/schema-then-query-001.yaml
+++ b/benchmarks/constraint-binding/tasks/schema-then-query-001.yaml
@@ -5,7 +5,7 @@ pre_state:
   fixture_tarball: schema-then-query-001.tar.gz
   source_repo: https://github.com/prisma/prisma-examples
   source_sha: 663c23ca1a6c6f03d2ad0c67868020b560a172e4
-  fixture_sha256: 1cbb0eba91f8e0662849bc6de629134f61c7c56709b4318a965f323c673a2af8
+  fixture_sha256: de86f10a22619212b8098f03cb813dae259b556515e52c40b6b7c979a9800be3
 prompt: |
   This fixture is the `databases/turso` example from prisma-examples — a
   small TypeScript project that uses Prisma against a Turso/libSQL backend.

--- a/scripts/fetch-fixtures.sh
+++ b/scripts/fetch-fixtures.sh
@@ -123,11 +123,25 @@ for row in "${ROWS[@]}"; do
     continue
   fi
 
-  # Deterministic export: git archive --format=tar emits tar entries with mtime
-  # set to the commit date, so the tar stream is bit-identical for a given SHA.
-  # Piping through `gzip -n` strips the gzip header's filename + mtime, making
-  # the .tar.gz reproducible too.
-  ( cd "$repo_cache" && git archive --format=tar "$sha" -- "$sub" ) | gzip -n > "$tar_out"
+  # Deterministic export: `git archive --format=tar <sha>[:<subpath>]` emits tar
+  # entries with mtime set to the commit date, so the tar stream is bit-identical
+  # for a given SHA. `gzip -n` strips the gzip header's filename + mtime so the
+  # .tar.gz is reproducible too.
+  #
+  # Subpath handling: `git archive <sha> -- <subpath>` preserves the subpath
+  # as a prefix on every tar entry (files appear as `databases/turso/...`).
+  # That's wrong for our use case — the task prompt tells the agent about
+  # files at `prisma/schema.prisma`, not `databases/turso/prisma/schema.prisma`,
+  # and the extracted workspace should match. `git archive <sha>:<subpath>`
+  # uses a tree-ish reference that treats the subpath as the archive root,
+  # producing entries without the prefix. Smoke3's schema-then-query pilot
+  # failure was the prefix-preserved variant masking the fixture's actual
+  # shape.
+  if [ "$sub" = "." ]; then
+    ( cd "$repo_cache" && git archive --format=tar "$sha" ) | gzip -n > "$tar_out"
+  else
+    ( cd "$repo_cache" && git archive --format=tar "${sha}:${sub}" ) | gzip -n > "$tar_out"
+  fi
 
   actual="$(sha256sum "$tar_out" | awk '{print $1}')"
   if [ "$hash" = "pending" ] || [ -z "$hash" ]; then


### PR DESCRIPTION
Applies the three pilot-hypothesis fixes from PR #22's N=1 scoreboard to the harness, validators, and fetch script **before** Phase 3b's 16-task expansion, so the new tasks inherit the fixes instead of re-discovering them.

## What's in this PR
1. **Fetch script: strip subpath prefix.** `git archive --format=tar <sha>:<subpath>` (tree-ish ref) replaces `git archive <sha> -- <subpath>` (prefix-preserving). Fixes the schema-then-query fixture landing at `databases/turso/prisma/schema.prisma` instead of `prisma/schema.prisma`. `.` case unchanged.
2. **Rename validator: exclude noise.** `--exclude-dir=node_modules` plus `--exclude='rename*.test.*'` on both positive and negative greps. Upstream deps (ava, consola, etc.) and self-asserting test files no longer produce false negatives.
3. **Lift-then-reuse validator: whitespace tolerance.** `function resolveScheduler[[:space:]]*\(` accepts both `resolveScheduler()` and `resolveScheduler ()`.

## Fixture hash update
schema-then-query-001 re-archived, new sha256 recorded in both `SOURCES.md` and the task YAML:
```
1cbb0eba91f8... → de86f10a22619...
```
Other three fixtures use subpath `.` and are unchanged. `--verify-only` passes 4/4.

## Verification
- `bash scripts/fetch-fixtures.sh --verify-only` → 4/4 matched
- `node benchmarks/constraint-binding/validator-engine.js lint tasks/` → 4 passed
- `mocha --grep "every pilot fixture"` baseline-rejection smoke → 4/4 baselines still rejected correctly (validators still have teeth after loosening)
- `npm run lint` clean
- `npm test` → 1483 passing, unchanged

## What this does NOT address
- The 16 new tasks for Phase 3b (follow-up PR, builds on this foundation).
- Orchestrator-side plan-generator fixes — already landed in #29/#30/#31.

## Test plan
- [x] `--verify-only` 4/4 after schema hash update
- [x] Pipeline smoke still rejects all 4 baselines (no over-relaxation)
- [x] Full suite unchanged
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)