### PR TITLE
feat(bench): union-based capture_agent_diff with reserved-paths constant (#27 issue 2 / 1b)

### DIFF
--- a/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
+++ b/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
@@ -31,6 +31,12 @@ from pathlib import Path
 from datasets import load_dataset
 from tqdm import tqdm
 
+# Local import — reserved-path list consumed by capture_agent_diff.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+from worktree_reserved_paths import git_pathspec_excludes  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -70,32 +76,125 @@ class DiffCaptureError(RuntimeError):
     """
 
 
-def capture_agent_diff(repo_dir: Path, base_commit: str) -> bytes:
+def load_agent_manifest(repo_dir: Path) -> list[str]:
+    """Aggregate per-step `filesChanged` lists from the orchestrator's
+    context-broker state. Returns a sorted list of repo-relative paths the
+    orchestrator recorded as agent-touched across every completed step.
+
+    Source of truth: `<repo_dir>/runs/swarm-*/.context/shared-context.json`.
+    That file is written by `ContextBroker.addStepContext()` after each
+    step's verification passes, with `data.filesChanged` populated from the
+    agent's `/share` transcript.
+
+    Completeness caveat (issue #27 Issue 2): this manifest is agent-self-
+    reported. Files the agent modified without recording in the transcript
+    are NOT listed here. capture_agent_diff compensates by additionally
+    staging OS-observed changes outside reserved paths — the "∪ OS-observed"
+    half of the option-1b union.
+
+    Missing or malformed manifest files are not fatal; returns [].
+    """
+    runs_root = repo_dir / "runs"
+    if not runs_root.is_dir():
+        return []
+    # Most-recent swarm-* run dir wins — one eval invocation produces one
+    # orchestrator run, but tests and dev environments may have leftovers.
+    candidates = sorted(
+        (p for p in runs_root.iterdir() if p.is_dir() and p.name.startswith("swarm-")),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        return []
+    ctx_file = candidates[0] / ".context" / "shared-context.json"
+    if not ctx_file.exists():
+        return []
+    try:
+        entries = json.loads(ctx_file.read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    files: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        data = entry.get("data") or {}
+        for f in data.get("filesChanged") or []:
+            if isinstance(f, str) and f:
+                files.add(f)
+    return sorted(files)
+
+
+def capture_agent_diff(
+    repo_dir: Path,
+    base_commit: str,
+    manifest_files: list[str] | None = None,
+) -> bytes:
     """Collect the agent's changes as a unified diff against the base commit.
 
-    Returns raw bytes. `git diff` output can contain non-UTF-8 content —
-    filenames in legacy encodings, binary-file marker lines with byte-level
-    metadata, or text files that aren't clean UTF-8 (latin-1 residue in
-    older repos, test fixtures with arbitrary byte sequences). Decoding at
-    capture time raises UnicodeDecodeError on real-world workdirs; callers
-    that need a string should decode at the point of use with
-    errors='replace' so a mangled filename doesn't crash the whole eval.
+    Union-based capture (issue #27 Issue 2 / option 1b). Two sources:
 
-    Intent-to-add staging picks up untracked files agents sometimes create
-    (new modules, fresh tests) so they show up in the diff instead of being
-    silently dropped.
+      1. **manifest_files** — files the agent claimed to touch, loaded
+         from the orchestrator's context-broker state. Each is staged for
+         intent-to-add directly, with no exclusion applied — an agent-
+         claimed modification inside an orchestrator-reserved path is
+         still intentional agent work and should appear in the diff.
+      2. **OS-observed changes outside reserved paths** — everything else
+         in the worktree that git sees as modified or untracked, minus
+         the reserved-path set from worktree_reserved_paths. Picks up
+         silent agent edits the transcript might have missed, without
+         letting orchestrator scratch (runs/, node_modules/, etc.) leak
+         into the diff.
+
+    The union covers both completeness gaps identified in the issue #27
+    halt report:
+      - agent silent edits → caught by source 2
+      - orchestrator-internal worktree writes → excluded by source 2's
+        reserved-path filter, and source 1's manifest never includes them
+        because the orchestrator doesn't write to its own transcripts.
+
+    Returns raw bytes. `git diff` output can contain non-UTF-8 content —
+    filenames in legacy encodings, binary-file markers, text files with
+    latin-1 residue. Decoding at capture time raises UnicodeDecodeError
+    on real-world workdirs; callers that need a string should decode at
+    the point of use with errors='replace'.
 
     @raises DiffCaptureError when the diff is empty (no changes — real
             failure) or larger than MAX_DIFF_BYTES (scope pollution).
     """
-    subprocess.run(
-        ["git", "add", "-A", "-N"],
-        cwd=str(repo_dir),
-        capture_output=True,
-        timeout=30,
-    )
+    # Source 1: explicit manifest files (no exclusion — agent claim wins).
+    if manifest_files:
+        for rel in manifest_files:
+            # Skip paths that traverse upward or escape the repo.
+            if rel.startswith("/") or ".." in Path(rel).parts:
+                continue
+            full = repo_dir / rel
+            # Only stage files that actually exist — a missing file means
+            # the agent claimed a deletion (git add -A picks that up via
+            # source 2) or hallucinated the claim (not our bug to fix).
+            if full.exists():
+                subprocess.run(
+                    ["git", "add", "-N", "--", rel],
+                    cwd=str(repo_dir),
+                    capture_output=True,
+                    timeout=30,
+                )
+
+    # Source 2: `-A -N` over the whole worktree, minus reserved paths.
+    # A positive pathspec (`.`) is required alongside negative excludes —
+    # an exclude-only pathspec list matches nothing in git.
+    add_cmd = ["git", "add", "-A", "-N", "--", "."] + git_pathspec_excludes()
+    subprocess.run(add_cmd, cwd=str(repo_dir), capture_output=True, timeout=30)
+
+    # Diff working-tree-vs-base rather than HEAD-vs-base. The orchestrator
+    # normally commits each step's work before this runs, so in the happy
+    # path either form gives the same result. But when an agent's edit
+    # landed in the working tree via intent-to-add (-N) without being
+    # committed — which happens when the orchestrator rolls back a step's
+    # commit but leaves the files, or when the agent writes uncommitted
+    # scratch files — `git diff <base>` still surfaces it while
+    # `git diff <base> HEAD` would miss it.
     result = subprocess.run(
-        ["git", "diff", base_commit, "HEAD"],
+        ["git", "diff", base_commit],
         cwd=str(repo_dir),
         capture_output=True,
         timeout=60,

--- a/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
+++ b/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
@@ -185,14 +185,11 @@ def capture_agent_diff(
     add_cmd = ["git", "add", "-A", "-N", "--", "."] + git_pathspec_excludes()
     subprocess.run(add_cmd, cwd=str(repo_dir), capture_output=True, timeout=30)
 
-    # Diff working-tree-vs-base rather than HEAD-vs-base. The orchestrator
-    # normally commits each step's work before this runs, so in the happy
-    # path either form gives the same result. But when an agent's edit
-    # landed in the working tree via intent-to-add (-N) without being
-    # committed — which happens when the orchestrator rolls back a step's
-    # commit but leaves the files, or when the agent writes uncommitted
-    # scratch files — `git diff <base>` still surfaces it while
-    # `git diff <base> HEAD` would miss it.
+    # Intentionally omits HEAD so working-tree changes (including intent-to-
+    # add silent edits staged by source 2 above) are captured. The `git diff
+    # <base> HEAD` form would silently exclude them — which is exactly the
+    # silent-edit case the union approach exists to surface. See #27 for
+    # context. Do not "fix" this to include HEAD without re-reading.
     result = subprocess.run(
         ["git", "diff", base_commit],
         cwd=str(repo_dir),

--- a/benchmarks/swe-bench/evaluation-scripts/worktree_reserved_paths.py
+++ b/benchmarks/swe-bench/evaluation-scripts/worktree_reserved_paths.py
@@ -1,0 +1,95 @@
+"""Reserved paths for agent-diff capture (issue #27 Issue 2 / option 1b).
+
+The orchestrator writes state to specific paths inside the agent's worktree
+during normal operation (run metadata, step worktrees, quality-gate output,
+planner scratch). Those paths must be excluded from the agent-diff or the
+diff balloons with orchestrator noise that has nothing to do with the
+agent's intent — exactly the 31.7 MB smoke3 failure mode.
+
+Two categories, tracked separately so audit decisions stay legible:
+
+  ORCHESTRATOR_RESERVED_PATHS — paths THIS codebase writes to as part of
+  normal operation. Scraped from `src/**/*.ts` via the audit that
+  accompanied issue #27's Issue 2 analysis. Update when a new code path
+  starts writing to a new top-level directory inside the worktree.
+
+  BUILD_ARTIFACT_RESERVED_PATHS — paths universal build tooling writes
+  (package managers, compilers, test runners, venv tools). Not
+  orchestrator-specific; reasonable to exclude from any agent-diff
+  regardless of subsystem.
+
+The union consumer is `capture_agent_diff`. The git pathspec form returned
+by `git_pathspec_excludes()` is what gets appended to `git add`.
+
+See src/plan-generator.ts context on Fixes 1-3 and the Issue 2 halt
+report on issue #27 for the failure mode motivating this module.
+"""
+from __future__ import annotations
+
+
+ORCHESTRATOR_RESERVED_PATHS: tuple[str, ...] = (
+    # runDir tree — holds everything orchestrator-scoped:
+    #   .context/shared-context.json (per-step manifest)
+    #   .locks/ (git serialization locks)
+    #   worktrees/step-N/ (per-step isolated worktrees)
+    #   steps/step-N/share.md (transcripts)
+    #   session-state.json, metrics.json, cost-attribution.json
+    #   quality-gates/ (gate output)
+    # Excluding "runs/" excludes every nested path, so we don't need to
+    # list .context/, .locks/, worktrees/ etc. individually.
+    "runs",
+    # quick-fix-mode session scratch (src/quick-fix-mode.ts:187)
+    ".quickfix",
+    # PlanStorage default writes plan-*.json here when planDir isn't set
+    # (src/plan-storage.ts:12)
+    "plans",
+)
+
+
+BUILD_ARTIFACT_RESERVED_PATHS: tuple[str, ...] = (
+    # Node
+    "node_modules",
+    # Python
+    "__pycache__",
+    ".venv",
+    "venv",
+    "env",
+    # JS build tools
+    ".next",
+    ".turbo",
+    ".cache",
+    # Generic build output
+    "dist",
+    "build",
+    # Test coverage
+    "coverage",
+)
+
+
+# Pure file-glob patterns (not directories). Appended separately from the
+# directory-glob expansion below.
+_FILE_GLOB_EXCLUDES: tuple[str, ...] = (
+    "**/*.pyc",
+    "**/*.pyo",
+    "**/*.egg-info",
+    "**/*.egg-info/**",
+)
+
+
+def git_pathspec_excludes() -> list[str]:
+    """Return git pathspec :(exclude) directives covering every reserved path.
+
+    For each directory entry, emits both the top-level form (`:(exclude)runs`)
+    and a tree glob (`:(exclude)runs/**`). Git requires both when the
+    exclude should match the directory itself AND everything under it; the
+    top-level form alone can miss deeply nested files on some git versions.
+
+    Consumers pass this list directly as trailing arguments to `git add`
+    after a positive pathspec (typically `.`).
+    """
+    specs: list[str] = []
+    for p in ORCHESTRATOR_RESERVED_PATHS + BUILD_ARTIFACT_RESERVED_PATHS:
+        specs.append(f":(exclude){p}")
+        specs.append(f":(exclude){p}/**")
+    specs.extend(f":(exclude){pat}" for pat in _FILE_GLOB_EXCLUDES)
+    return specs

--- a/benchmarks/swe-bench/tests/test_union_capture.py
+++ b/benchmarks/swe-bench/tests/test_union_capture.py
@@ -1,0 +1,314 @@
+"""Regression tests for issue #27 Issue 2 / option 1b — manifest ∪ OS-observed
+capture with centralized reserved-paths.
+
+Core contract (from the #27 halt report):
+  the captured diff = {manifest files} ∪ {OS-observed changes outside
+  reserved paths}
+
+Four-quadrant test verifies every combination of (agent-claimed, OS-visible,
+reserved-path) holds:
+  (A) agent claims file X, X exists, X is outside reserved → IN the diff
+  (B) agent silently modifies Y without claiming it, Y is outside reserved →
+      IN the diff (manifest gap closed by OS-observed source)
+  (C) orchestrator writes Z under a reserved path → NOT in the diff
+      (runs/ is the ambient example)
+  (D) orchestrator writes W to a non-reserved path (hypothetical bug) → IN
+      the diff (we surface it rather than hide it). If D starts showing up
+      as normal orchestrator operation rather than a bug, that's the halt
+      signal from the #27 Issue 2 scope discussion.
+
+Run:
+  python3 -m pytest benchmarks/swe-bench/tests/test_union_capture.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "run_swebench",
+    _HERE.parent / "evaluation-scripts" / "run_swebench.py",
+)
+_module = importlib.util.module_from_spec(_SPEC)
+try:
+    _SPEC.loader.exec_module(_module)  # type: ignore[union-attr]
+except Exception as exc:  # pragma: no cover
+    pytest.skip(f"run_swebench.py did not import cleanly: {exc}", allow_module_level=True)
+
+capture_agent_diff = _module.capture_agent_diff
+load_agent_manifest = _module.load_agent_manifest
+
+# Import the reserved-paths module directly so the test can exercise its
+# public surface independent of run_swebench.py's integration.
+_RESERVED_SPEC = importlib.util.spec_from_file_location(
+    "worktree_reserved_paths",
+    _HERE.parent / "evaluation-scripts" / "worktree_reserved_paths.py",
+)
+_reserved = importlib.util.module_from_spec(_RESERVED_SPEC)
+_RESERVED_SPEC.loader.exec_module(_reserved)  # type: ignore[union-attr]
+ORCHESTRATOR_RESERVED_PATHS = _reserved.ORCHESTRATOR_RESERVED_PATHS
+BUILD_ARTIFACT_RESERVED_PATHS = _reserved.BUILD_ARTIFACT_RESERVED_PATHS
+git_pathspec_excludes = _reserved.git_pathspec_excludes
+
+
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        env={**GIT_ENV},
+        timeout=30,
+        check=False,
+    )
+
+
+def _seed_repo(tmp: Path) -> str:
+    _git(tmp, "init", "-q")
+    _git(tmp, "config", "user.email", "t@t")
+    _git(tmp, "config", "user.name", "t")
+    (tmp / "README.md").write_text("seed\n")
+    _git(tmp, "add", ".")
+    _git(tmp, "commit", "-m", "seed")
+    return _git(tmp, "rev-parse", "HEAD").stdout.decode().strip()
+
+
+def test_reserved_paths_list_is_bounded():
+    """Halt-signal test from #27: if the reserved-paths list grows past 15
+    entries, the codebase is arguing for option 2 (restructure orchestrator
+    writes) rather than option 1b (exclude-list). Lock in a bound so that
+    crossing it surfaces at test time, not silently."""
+    total = (
+        len(ORCHESTRATOR_RESERVED_PATHS)
+        + len(BUILD_ARTIFACT_RESERVED_PATHS)
+    )
+    assert total <= 15, (
+        f"reserved-paths list has grown to {total} entries. The #27 Issue 2 "
+        f"analysis called out 15+ as the signal that option 2 is being "
+        f"argued for by the codebase's actual structure. Review whether "
+        f"each new path is genuinely orchestrator-owned before adding it."
+    )
+
+
+def test_four_quadrant_union():
+    """The core option-1b contract, worked through all four quadrants.
+
+    Quadrant A: agent claims file, exists, outside reserved → IN diff
+    Quadrant B: silent agent edit, outside reserved → IN diff
+    Quadrant C: orchestrator scratch under reserved path → NOT in diff
+    Quadrant D: orchestrator wrote to non-reserved path → IN diff
+    """
+    with tempfile.TemporaryDirectory(prefix="union-4q-") as t:
+        tmp = Path(t)
+        base = _seed_repo(tmp)
+
+        # (A) agent-claimed + exists + outside reserved → in diff
+        (tmp / "src").mkdir()
+        (tmp / "src" / "a.py").write_text("# agent claims this change\n")
+
+        # (B) silent agent edit outside reserved → in diff (OS-observed)
+        (tmp / "src" / "b.py").write_text("# agent edited but did not claim\n")
+
+        # (C) orchestrator scratch under `runs/` — reserved → excluded
+        (tmp / "runs" / "swarm-xyz").mkdir(parents=True)
+        (tmp / "runs" / "swarm-xyz" / "session-state.json").write_text('{"noise":1}\n')
+
+        # (D) hypothetical orchestrator bug writes to a non-reserved path → in diff
+        (tmp / "docs").mkdir()
+        (tmp / "docs" / "d.txt").write_text("orchestrator-written, non-reserved\n")
+
+        # Commit A + D so git diff <base>..HEAD will surface them (matches
+        # the real orchestrator shape where the integration branch has
+        # committed state by the time the diff is captured). B stays
+        # uncommitted as a "silent edit in working tree" — source 2 stages
+        # it for intent-to-add.
+        _git(tmp, "add", "src/a.py", "docs/d.txt")
+        _git(tmp, "commit", "-m", "committed changes")
+
+        # Manifest contains A only (the agent claimed A, did not claim B
+        # because the silent-edit blind spot is the whole point of this
+        # test).
+        manifest = ["src/a.py"]
+
+        raw = capture_agent_diff(tmp, base, manifest_files=manifest)
+        diff = raw.decode("utf-8", errors="replace")
+
+        # A — agent-claimed, committed, outside reserved → present
+        assert "src/a.py" in diff, "A (agent-claimed + committed) must be in the diff"
+
+        # B — silent edit, staged via source 2's -A -N → present
+        assert "src/b.py" in diff, (
+            "B (silent agent edit outside reserved) must be in the diff — this "
+            "is the completeness gap source 2 closes"
+        )
+
+        # C — under runs/ → excluded by reserved-path rule
+        assert "runs/swarm-xyz" not in diff, (
+            "C (orchestrator scratch under runs/) must NOT be in the diff"
+        )
+        assert "session-state.json" not in diff, (
+            "C (session-state.json under runs/) must NOT be in the diff"
+        )
+
+        # D — non-reserved path → present (whether the orchestrator should
+        # have written there is a separate question the halt condition
+        # covers; for THIS contract, the diff faithfully reports it)
+        assert "docs/d.txt" in diff, (
+            "D (orchestrator wrote to non-reserved path, hypothetical bug) "
+            "must be in the diff — we surface this rather than hide it, so "
+            "a regression where the orchestrator routinely writes outside "
+            "reserved paths becomes visible in eval output."
+        )
+
+
+def test_manifest_file_under_reserved_path_is_staged_explicitly():
+    """Edge case: agent claims modification to a file that happens to live
+    under an orchestrator-reserved path. Source 1 (manifest) stages it
+    regardless; source 2 would have excluded it. The union includes it
+    because agent claim wins.
+
+    This is unusual in practice but covers the fairness question: if the
+    orchestrator's reserved-path list ever overlaps with something the
+    agent legitimately needs to touch, the manifest-based source 1 keeps
+    that work visible.
+    """
+    with tempfile.TemporaryDirectory(prefix="union-reserved-") as t:
+        tmp = Path(t)
+        base = _seed_repo(tmp)
+
+        # Agent modifies a file inside a reserved directory. `plans/` is
+        # reserved; the agent claims it.
+        (tmp / "plans").mkdir()
+        (tmp / "plans" / "agent-owned.json").write_text('{"agent":"wrote this"}\n')
+        _git(tmp, "add", "plans/agent-owned.json")
+        _git(tmp, "commit", "-m", "agent work under reserved path")
+
+        diff = capture_agent_diff(
+            tmp, base, manifest_files=["plans/agent-owned.json"]
+        ).decode("utf-8", errors="replace")
+
+        assert "plans/agent-owned.json" in diff, (
+            "manifest-claimed file under reserved path must still appear in "
+            "the diff — agent claim overrides the reserved-path filter"
+        )
+
+
+def test_manifest_loader_handles_missing_and_malformed_state():
+    """load_agent_manifest must not raise on a missing runs/ dir, missing
+    shared-context.json, or malformed JSON — the caller can't rely on the
+    orchestrator having produced valid state, and failing the eval because
+    the manifest wasn't readable defeats the whole point."""
+    with tempfile.TemporaryDirectory(prefix="union-manifest-") as t:
+        tmp = Path(t)
+
+        # No runs/ dir at all
+        assert load_agent_manifest(tmp) == []
+
+        # Empty runs/ dir
+        (tmp / "runs").mkdir()
+        assert load_agent_manifest(tmp) == []
+
+        # runs/ dir with a non-swarm sibling
+        (tmp / "runs" / "not-a-swarm-run").mkdir()
+        assert load_agent_manifest(tmp) == []
+
+        # swarm run dir but no .context
+        (tmp / "runs" / "swarm-2026").mkdir()
+        assert load_agent_manifest(tmp) == []
+
+        # .context dir but no shared-context.json
+        (tmp / "runs" / "swarm-2026" / ".context").mkdir()
+        assert load_agent_manifest(tmp) == []
+
+        # Malformed JSON
+        (tmp / "runs" / "swarm-2026" / ".context" / "shared-context.json").write_text(
+            "not valid json {",
+        )
+        assert load_agent_manifest(tmp) == []
+
+
+def test_manifest_loader_aggregates_across_steps():
+    """Happy path: shared-context.json contains one entry per completed
+    step; the manifest is the sorted union of every entry's filesChanged."""
+    with tempfile.TemporaryDirectory(prefix="union-aggregate-") as t:
+        tmp = Path(t)
+        ctx_dir = tmp / "runs" / "swarm-latest" / ".context"
+        ctx_dir.mkdir(parents=True)
+        (ctx_dir / "shared-context.json").write_text(
+            json.dumps([
+                {
+                    "stepNumber": 1,
+                    "agentName": "BackendMaster",
+                    "timestamp": "2026-04-21T10:00:00Z",
+                    "data": {
+                        "filesChanged": ["src/auth.ts", "src/session.ts"],
+                        "outputsSummary": "",
+                    },
+                },
+                {
+                    "stepNumber": 2,
+                    "agentName": "TesterElite",
+                    "timestamp": "2026-04-21T10:15:00Z",
+                    "data": {
+                        "filesChanged": ["test/auth.test.ts"],
+                        "outputsSummary": "",
+                    },
+                },
+                # An entry with no filesChanged — should be skipped, not error
+                {
+                    "stepNumber": 3,
+                    "agentName": "IntegratorFinalizer",
+                    "timestamp": "2026-04-21T10:30:00Z",
+                    "data": {"outputsSummary": "no files"},
+                },
+            ]),
+        )
+
+        manifest = load_agent_manifest(tmp)
+        assert manifest == [
+            "src/auth.ts",
+            "src/session.ts",
+            "test/auth.test.ts",
+        ], "sorted union of every step's filesChanged, duplicates de-duped"
+
+
+def test_manifest_rejects_path_traversal_and_absolute_entries():
+    """Defense in depth: a malformed or adversarial manifest shouldn't be
+    able to trick capture_agent_diff into touching files outside the
+    worktree. Absolute paths and `..` traversal get silently dropped."""
+    with tempfile.TemporaryDirectory(prefix="union-safety-") as t:
+        tmp = Path(t)
+        base = _seed_repo(tmp)
+
+        # Make at least one real change so the diff isn't empty
+        (tmp / "legit.txt").write_text("legit agent change\n")
+        _git(tmp, "add", "legit.txt")
+        _git(tmp, "commit", "-m", "legit")
+
+        # Manifest tries to escape. These must not crash, not raise, not
+        # produce any git operations on those paths.
+        adversarial = [
+            "/etc/passwd",
+            "../../../../etc/passwd",
+            "legit.txt",  # the legitimate one
+        ]
+        diff = capture_agent_diff(tmp, base, manifest_files=adversarial).decode(
+            "utf-8", errors="replace",
+        )
+
+        assert "legit.txt" in diff
+        assert "/etc/passwd" not in diff


### PR DESCRIPTION
Implements **option 1b** from the #27 Issue 2 halt report. Closes both completeness gaps the halt identified.

## Halt-check answers
- **Reserved-paths list size:** 14 entries (3 orchestrator-specific + 11 build-artifact). Bounded to ≤15 by an explicit test (`test_reserved_paths_list_is_bounded`). If a future write-path audit pushes it past 15, that test fails and surfaces the option-2 argument as design pressure.
- **Orchestrator writes to non-reserved paths as normal operation?** No. Audited every `mkdirSync` / `writeFileSync` / `path.join(workingDir, ...)` in `src/`. Writes land in `runs/` (catches nested `.context/`, `.locks/`, `worktrees/`, etc.), `.quickfix/`, or `plans/`. Nothing writes outside those directories as normal operation.

## What's in
- **`benchmarks/swe-bench/evaluation-scripts/worktree_reserved_paths.py`** — centralized constant + `git_pathspec_excludes()` helper. Categorized into `ORCHESTRATOR_RESERVED_PATHS` (3) and `BUILD_ARTIFACT_RESERVED_PATHS` (11). Comments reference the specific `src/` line numbers each entry protects against.
- **`capture_agent_diff`** — now takes optional `manifest_files`. Source 1 stages each manifest file explicitly (no exclusion, agent claim wins). Source 2 stages everything else via `git add -A -N -- . <excludes>`. Diff command changed from `git diff <base> HEAD` to `git diff <base>` so working-tree-vs-base includes intent-to-add'd files.
- **`load_agent_manifest(repo_dir)`** — reads `<repo_dir>/runs/swarm-*/.context/shared-context.json` and returns sorted union of `filesChanged` across every step's entry. Robust to missing/malformed state.

## Four-quadrant regression test
Per your #27 spec:
| | Agent claims | OS visible | Reserved path | Expected |
|---|---|---|---|---|
| A | ✓ | ✓ | ✗ | in diff |
| B | ✗ | ✓ | ✗ | in diff (source 2) |
| C | ✗ | ✓ | ✓ | NOT in diff |
| D | ✗ | ✓ | ✗ | in diff (surfaces bug) |

All four assertions green in one test (`test_four_quadrant_union`).

## Design points for review

1. **Reserved-paths location.** Chose `benchmarks/swe-bench/evaluation-scripts/` because `capture_agent_diff` is Python and lives there; the orchestrator (TypeScript) doesn't currently need the list. If a Node-side consumer surfaces later, the natural move is a JSON constant both languages read, or duplicate TS constant with a test keeping them in sync. Not doing that speculatively.

2. **Diff command switch: `git diff <base>` not `git diff <base> HEAD`.** The HEAD form misses intent-to-add'd files that haven't been committed yet — exactly the silent-edit case source 2 needs to surface. Non-HEAD form is working-tree-vs-base, which is strictly more complete. In the happy path (orchestrator commits each step's work), both give identical output. Flag if you'd prefer the HEAD form retained for other reasons; the union contract fails with HEAD.

3. **Manifest source: `shared-context.json`, not `session-state.json`.** The #27 halt report already flagged this rename. JSDoc + comments in the PR reference the correct location throughout.

4. **Quadrant D assertion.** Test asserts a hypothetical orchestrator bug that writes to a non-reserved path DOES appear in the diff. Rationale: surface bugs rather than hide them. If the halt condition is tripped (orchestrator routinely writes to non-reserved paths), smoke results will contain extra noise — visible in eval output, flagged by inspection — instead of being silently filtered.

5. **`git diff <base>` semantics note.** For SWE-bench's use case (agent diff goes to container for patch application), working-tree semantics is strictly more correct: staged changes should apply too. For future non-SWE-bench callers who want commit-only state, they'd need to opt in with a flag. Not adding that flag speculatively.

## Not wired into the main eval loop in this PR
`capture_agent_diff`'s only caller in this PR is the test suite. The `run_orchestrator → run_tests_dispatch` wiring that calls it from the main loop lives on the held-back `feat/swe-bench-setup` branch (Phase 4a landing pad). When smoke4 resumes after this lands, the eval loop picks up the union-aware capture automatically.

## Verification
- `python3 -m pytest benchmarks/swe-bench/tests/` → **9 passing** (3 existing + 6 new)
- `npm run typecheck` clean
- `npm run lint` clean
- `npm test` → 1483 passing, unchanged

## What this unblocks
- **Phase 4a smoke4** — ready to run once this lands and the `feat/swe-bench-setup` branch rebases onto main.

## Test plan
- [x] Four-quadrant contract asserted end-to-end
- [x] Reserved-paths list ≤15 enforced by test
- [x] Manifest loader robust to missing/malformed state
- [x] Path traversal attempts neutralized
- [x] Existing capture_agent_diff tests still pass
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)