### PR TITLE
feat(orchestrator): target-mode gate scoping (#27 PR 1)

### DIFF
--- a/src/cli/swarm-handlers.ts
+++ b/src/cli/swarm-handlers.ts
@@ -193,7 +193,14 @@ export async function executeSwarm(
     logger.info(`📂 Target directory: ${targetDir}`);
   }
 
-  const orchestrator = new SwarmOrchestrator(targetDir);
+  // targetMode: structural discriminator for whether this run is against an
+  // external repo (bootstrap / swarm against a target dir) vs the
+  // orchestrator's own cwd (self-improvement). Drives quality-gate scoping:
+  // orchestrator-internal gates (duplicateBlocks, accessibility, etc.) skip
+  // in target mode; universal gates (hardcodedConfig, testFileProtection)
+  // always fire. See SELF_IMPROVEMENT_GATE_KEYS and #27 Phase-4a smoke4.
+  const targetMode = Boolean(targetDir);
+  const orchestrator = new SwarmOrchestrator(targetDir, targetMode);
 
   const runId = `swarm-${new Date().toISOString().replace(/[:.]/g, '-')}`;
   const baseDir = targetDir || process.cwd();

--- a/src/quality-gates/gate-runner.ts
+++ b/src/quality-gates/gate-runner.ts
@@ -30,7 +30,8 @@ export async function run_quality_gates(
   outDir?: string,
   baselineFiles?: Set<string>,
   baseCommit?: string,
-  skippedRequirementIds?: Set<string>
+  skippedRequirementIds?: Set<string>,
+  skippedGateKeys?: ReadonlySet<string>,
 ): Promise<QualityGatesRunResult> {
   const start = Date.now();
 
@@ -67,6 +68,26 @@ export async function run_quality_gates(
   for (const gate of getRegisteredGates()) {
     const gateConfig = config.gates[gate.key];
     if (!gateConfig?.enabled) continue;
+    // Target-mode skip: self-improvement gates the caller has opted out of
+    // for this run (orchestrator passes SELF_IMPROVEMENT_GATE_KEYS when
+    // targetMode === true — running against an external repo whose
+    // conventions aren't ours to enforce). Universal gates (hardcodedConfig,
+    // testFileProtection) are never in this set. See registry.ts.
+    if (skippedGateKeys?.has(gate.key)) {
+      // Match the kebab-case id convention that the fired gates emit
+      // (e.g. 'duplicateBlocks' registry key → 'duplicate-blocks' id).
+      // Downstream consumers look gates up by id, so skipped entries need
+      // the same id shape as run entries for the same gate.
+      const id = gate.key.replace(/[A-Z]/g, m => '-' + m.toLowerCase());
+      gateResults.push({
+        id,
+        title: gate.title,
+        status: 'skip',
+        durationMs: 0,
+        issues: [],
+      });
+      continue;
+    }
     gateResults.push(await gate.run(ctx, gateConfig, config.maxFileSizeBytes));
   }
 

--- a/src/quality-gates/registry.ts
+++ b/src/quality-gates/registry.ts
@@ -107,6 +107,39 @@ export function loadProjectGateRegistrations(projectRoot: string): string[] {
   return [entryPath];
 }
 
+/**
+ * Gate keys that are "self-improvement" gates — the orchestrator applies
+ * them to its OWN generated code to enforce quality on code it produced.
+ * When the orchestrator is running against a target repo (swarm bootstrap
+ * against an external codebase), these gates should NOT fire: the target
+ * has its own conventions and the gates misattribute target-repo features
+ * as agent defects. Phase 4a smoke4 evidence: the accessibility gate
+ * flagged sympy (computer-algebra library, no UI) and triggered replan
+ * churn that wasted cycles and polluted the diff-capture.
+ *
+ * Gates NOT in this set are "universal" — they enforce agent-behavior
+ * contracts that apply regardless of whose codebase is being modified:
+ *   - hardcodedConfig       agent must not add secrets / hardcoded config
+ *                           (the gate scopes to baselineFiles, so it only
+ *                           flags what the agent added, not pre-existing
+ *                           target state — safe in target mode)
+ *   - testFileProtection    agent must not modify pre-existing test files
+ *                           (SWE-bench evaluation integrity + general
+ *                           safety property; always fires)
+ *
+ * `run_quality_gates` consults this set via the `skippedGateKeys` param
+ * the orchestrator passes when `targetMode === true`.
+ */
+export const SELF_IMPROVEMENT_GATE_KEYS: ReadonlySet<string> = new Set([
+  'scaffoldDefaults',
+  'duplicateBlocks',
+  'readmeClaims',
+  'testIsolation',
+  'runtimeChecks',
+  'accessibility',
+  'testCoverage',
+]);
+
 registerBuiltInGate({
   key: 'scaffoldDefaults',
   title: 'Scaffold Defaults',

--- a/src/swarm-orchestrator.ts
+++ b/src/swarm-orchestrator.ts
@@ -14,6 +14,7 @@ import MetricsCollector from './metrics-collector';
 import { ExecutionPlan, PlanGenerator, PlanStep, ReplanPayload } from './plan-generator';
 import PRAutomation from './pr-automation';
 import { load_quality_gates_config, run_quality_gates } from './quality-gates';
+import { SELF_IMPROVEMENT_GATE_KEYS } from './quality-gates/registry';
 import type { GateResult } from './quality-gates';
 import RepairAgent, { RepairContext } from './repair-agent';
 import SessionExecutor, { SessionOptions, SessionResult } from './session-executor';
@@ -153,8 +154,31 @@ export class SwarmOrchestrator {
   private pauseRequested: boolean = false;
   private resumeRequested: boolean = false;
 
-  constructor(workingDir?: string) {
+  /**
+   * `targetMode` is true when the orchestrator is operating on an external
+   * target repo (e.g. `swarm bootstrap ./external-repo`, the SWE-bench
+   * harness). False when operating on its own codebase (self-improvement
+   * runs). Structural signal, not keyword-based: the caller passes a
+   * truthy `workingDir` that is not the orchestrator's own cwd, and the
+   * CLI dispatcher sets `targetMode = true` at that boundary.
+   *
+   * Drives two behaviors:
+   *   1. Orchestrator-internal quality gates (scaffoldDefaults,
+   *      duplicateBlocks, readmeClaims, testIsolation, runtimeChecks,
+   *      accessibility, testCoverage) are skipped when targetMode is
+   *      true — those enforce conventions on the orchestrator's own
+   *      generated code, not on arbitrary target repos. See #27 Phase-4a
+   *      smoke4 for the failure mode this prevents.
+   *   2. Verifier per-step outcome checks (git_diff, file_existence,
+   *      build_exec, test_exec) are NOT affected by targetMode. Those
+   *      are the orchestrator's verification contract for detecting
+   *      agent lies about their own work, and apply universally.
+   */
+  private targetMode: boolean;
+
+  constructor(workingDir?: string, targetMode: boolean = false) {
     this.workingDir = workingDir || process.cwd();
+    this.targetMode = targetMode;
     this.sessionExecutor = new SessionExecutor(this.workingDir);
     this.shareParser = new ShareParser();
     this.verifier = new VerifierEngine(this.workingDir);
@@ -634,7 +658,15 @@ export class SwarmOrchestrator {
       const skippedReqIds = context.filteredRequirements
         ? new Set(context.filteredRequirements.skipped.map(r => r.id))
         : undefined;
-      let gatesResult = await run_quality_gates(this.workingDir, gatesConfig, gatesOut, baselineFiles, baseCommit, skippedReqIds);
+      // targetMode: skip orchestrator-internal self-improvement gates when
+      // we're operating on an external repo. Universal gates
+      // (hardcodedConfig, testFileProtection) continue to fire. See
+      // registry.ts for the classification rationale.
+      const skippedGateKeys = this.targetMode ? SELF_IMPROVEMENT_GATE_KEYS : undefined;
+      let gatesResult = await run_quality_gates(
+        this.workingDir, gatesConfig, gatesOut, baselineFiles, baseCommit,
+        skippedReqIds, skippedGateKeys,
+      );
       context.finalGateResults = gatesResult.results;
 
       if (!gatesResult.passed && gatesConfig.failOnIssues) {
@@ -746,7 +778,10 @@ export class SwarmOrchestrator {
           if (addSteps.length > 0) {
             remediationAttempted = true;
             await this.executeReplan(context, { retrySteps: [], addSteps }, agentMap, options);
-            gatesResult = await run_quality_gates(this.workingDir, gatesConfig, gatesOut, baselineFiles, baseCommit, skippedReqIds);
+            gatesResult = await run_quality_gates(
+              this.workingDir, gatesConfig, gatesOut, baselineFiles, baseCommit,
+              skippedReqIds, skippedGateKeys,
+            );
             context.finalGateResults = gatesResult.results;
 
             // Second remediation attempt if gates still fail after first fix
@@ -783,7 +818,10 @@ export class SwarmOrchestrator {
                   addSteps: [{ agent: retryAgent, task: retryTask, afterStep: retryMaxStep }]
                 }, agentMap, options);
 
-                gatesResult = await run_quality_gates(this.workingDir, gatesConfig, gatesOut, baselineFiles, baseCommit, skippedReqIds);
+                gatesResult = await run_quality_gates(
+                  this.workingDir, gatesConfig, gatesOut, baselineFiles, baseCommit,
+                  skippedReqIds, skippedGateKeys,
+                );
                 context.finalGateResults = gatesResult.results;
               }
             }

--- a/test/quality-gates.test.ts
+++ b/test/quality-gates.test.ts
@@ -43,6 +43,94 @@ describe('QualityGates', () => {
     assert.ok(failed.includes('test-isolation'));
   });
 
+  describe('target-mode gate scoping (issue #27 PR 1)', () => {
+    // Uses bad-scaffold fixture which is known to fail multiple gates.
+    // In self-mode the fail set includes self-improvement gates
+    // (scaffold-defaults, readme-claims, test-isolation) plus the
+    // universal gate hardcoded-config. Target-mode must skip the
+    // self-improvement ones while still running hardcoded-config and
+    // test-file-protection.
+    const root = fixture('bad-scaffold');
+
+    it('self-mode (default): all enabled gates fire including self-improvement ones', async () => {
+      const cfg = load_quality_gates_config(root);
+      const result = await run_quality_gates(root, cfg);
+      const resultById = new Map(result.results.map(r => [r.id, r]));
+
+      // Self-improvement gates: were they executed (any status != skip)?
+      for (const id of ['scaffold-defaults', 'readme-claims', 'test-isolation']) {
+        const r = resultById.get(id);
+        assert.ok(r, `self-mode must report ${id}`);
+        assert.notStrictEqual(
+          r.status, 'skip',
+          `self-mode must RUN ${id}, not skip it`,
+        );
+      }
+    });
+
+    it('target-mode: self-improvement gates are skipped; universal gates run', async () => {
+      // Import here to avoid polluting the other tests' import surface.
+      const { SELF_IMPROVEMENT_GATE_KEYS } = require('../src/quality-gates/registry');
+      const cfg = load_quality_gates_config(root);
+      const result = await run_quality_gates(
+        root, cfg, undefined, undefined, undefined, undefined,
+        SELF_IMPROVEMENT_GATE_KEYS,
+      );
+      const resultById = new Map(result.results.map(r => [r.id, r]));
+
+      // Self-improvement gates must be present with status=skip.
+      for (const id of [
+        'scaffold-defaults', 'duplicate-blocks', 'readme-claims',
+        'test-isolation', 'runtime-checks', 'accessibility', 'test-coverage',
+      ]) {
+        const r = resultById.get(id);
+        assert.ok(r, `target-mode must still REPORT ${id}, with status=skip`);
+        assert.strictEqual(
+          r.status, 'skip',
+          `target-mode must skip ${id} (self-improvement)`,
+        );
+        assert.strictEqual(
+          r.issues.length, 0,
+          `target-mode skipped gates must have zero issues`,
+        );
+      }
+
+      // Universal gates must still run (not skip).
+      for (const id of ['hardcoded-config', 'test-file-protection']) {
+        const r = resultById.get(id);
+        assert.ok(r, `target-mode must still run universal gate ${id}`);
+        assert.notStrictEqual(
+          r.status, 'skip',
+          `target-mode must NOT skip universal gate ${id}`,
+        );
+      }
+    });
+
+    it('SELF_IMPROVEMENT_GATE_KEYS has the exact expected membership', async () => {
+      // Lock in the classification — any change to this set changes gate
+      // behavior in target-mode runs (SWE-bench eval, bootstrap against
+      // external repos). Test forces the decision to be explicit.
+      const { SELF_IMPROVEMENT_GATE_KEYS } = require('../src/quality-gates/registry');
+      const actual = new Set(SELF_IMPROVEMENT_GATE_KEYS);
+
+      const expected = new Set([
+        'scaffoldDefaults',
+        'duplicateBlocks',
+        'readmeClaims',
+        'testIsolation',
+        'runtimeChecks',
+        'accessibility',
+        'testCoverage',
+      ]);
+
+      assert.deepStrictEqual(
+        [...actual].sort(), [...expected].sort(),
+        'classification drift — confirm each added/removed gate is genuinely ' +
+        'self-improvement (target-mode skip) vs universal (target-mode fire)',
+      );
+    });
+  });
+
   it('runs explicitly registered custom project gates', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-gate-run-'));
     try {


### PR DESCRIPTION
Implements PR 1 from #27's Phase 4a unblock queue. Skips orchestrator-internal self-improvement gates when operating on an external target repo; universal gates keep firing.

## Halt-check answers (per your Phase 4a / PR 1 specification)

**1. Clean chokepoint for the targetMode discriminator?** ✓ Yes.
- Dispatch: `src/quality-gates/gate-runner.ts:67` — single for-loop over registered gates. New `skippedGateKeys?: ReadonlySet<string>` param short-circuits to skip-emission inside the loop.
- Discriminator: `src/cli/swarm-handlers.ts:186-202` — `targetDir` resolution already exists as the structural signal. `targetMode = Boolean(targetDir)` is the one-line bridge.
- Zero refactor required; zero per-code-path duplication.

**2. Classification ambiguity?** ✓ None.
- 7 self-improvement gates (skip in target mode): scaffoldDefaults, duplicateBlocks, readmeClaims, testIsolation, runtimeChecks, accessibility, testCoverage
- 2 universal gates (always fire): hardcodedConfig, testFileProtection

Classification rationale is documented inline on `SELF_IMPROVEMENT_GATE_KEYS` in registry.ts. Borderline cases I resolved explicitly:
- **runtimeChecks** (eslint) → self-improvement. The gate runs the project's own eslint config and fails on any errors; in target mode that'd fail on target-repo errors the agent didn't introduce.
- **testIsolation** → self-improvement. Target repos have their own test conventions; this enforces ours.
- **hardcodedConfig** → universal. Scopes to `baselineFiles`, so only flags what the agent added; safe in target mode.
- **testFileProtection** → universal. SWE-bench evaluation integrity (gold test patch only applies when agent didn't touch tests) plus general safety property.

**3. Verifier per-step outcome checks NOT skipped?** ✓ Confirmed.
- `git_diff`, `file_existence`, `build_exec`, `test_exec` live in `src/verifier/outcome-checks.ts` and run via `VerifierEngine.verifyStep`, separate code path from `run_quality_gates`. This PR touches only the quality-gates dispatch; verification-contract checks fire in both modes.
- This is the orchestrator's core value proposition (catching agent lies about their own work); weakening it would defeat the point.

## Discriminator logic in detail

- **Entry points setting targetMode=true:** `swarm bootstrap <external-repo>` (populates `plan.metadata.targetDir`), `swarm run --target <dir>` / `--dir <dir>`, any plan whose steps have an explicit `repo` field, and any plan file found under `<external-dir>/plans/`.
- **Entry points setting targetMode=false (default):** `swarm run` without target-resolving signals (the common case of operating on the orchestrator's own cwd for self-improvement).
- **No keyword-based branching.** Purely the structural `Boolean(targetDir)` check at one dispatch site.
- **Tests and MCP consumers** instantiate `new SwarmOrchestrator(dir)` with one arg; the second-arg default is `false`, preserving self-mode behavior. No test updates required for pre-existing suites.

## The gates skipped in target mode

`SELF_IMPROVEMENT_GATE_KEYS` contains exactly 7 entries. The constant is locked in by a set-equality test (`SELF_IMPROVEMENT_GATE_KEYS has the exact expected membership`) so any drift fails immediately with a clear message.

Universal gates kept running:
- `hardcodedConfig` — flags secrets/hardcoded values the agent *adds*. Agent-behavior contract, not a target-repo-convention check.
- `testFileProtection` — flags agent modifications to pre-existing test files. Critical for SWE-bench (gold test patch depends on it) and a general safety property.

## Verification
- `npm run typecheck` clean
- `npm run lint` clean
- `npm test` → 1483 → 1486 passing, 0 regressions

## Test plan
- [x] `SELF_IMPROVEMENT_GATE_KEYS` exact membership locked in
- [x] Self-mode test: self-improvement gates fire (no regression)
- [x] Target-mode test: self-improvement gates show status=skip, zero issues
- [x] Target-mode test: hardcoded-config + test-file-protection still run
- [x] Pre-existing SwarmOrchestrator tests unchanged (default targetMode=false)
- [ ] CI green on the branch

## What unblocks on merge
Smoke5 on sympy__sympy-12481 with all four fixes applied (planner Fixes 1/2/3 + union capture + target-mode gate scoping). If the diff size drops below 10 MB, PR 2 (commit-level exclude) is unnecessary and we can run a real eval. If it stays above, PR 2 becomes the next fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)