### PR TITLE
feat(commit): exclude reserved paths from per-step auto-commits (issue #27 / PR 2)

### DIFF
--- a/src/swarm-orchestrator.ts
+++ b/src/swarm-orchestrator.ts
@@ -29,6 +29,7 @@ import FleetExecutor from './fleet-executor';
 import { CostAttribution, CostHistoryEvidence, StepCostRecord } from './metrics-types';
 import PRManager from './pr-manager';
 import { WorktreeManager } from './worktree-manager';
+import { gitPathspecExcludes } from './worktree-reserved-paths';
 import { BranchMerger, MergeContext } from './branch-merger';
 import { BaselineSnapshot, scanBaseline } from './baseline-scanner';
 import { TaskClassifier } from './task-classifier';
@@ -1532,7 +1533,17 @@ export class SwarmOrchestrator {
       try {
         const status = execSync('git status --porcelain', { cwd: worktreePath, encoding: 'utf8' }).trim();
         if (status) {
-          execSync('git add -A', { cwd: worktreePath, stdio: 'pipe' });
+          // Exclude orchestrator-reserved and build-artifact paths from per-step commits.
+          // Bare `git add -A` captures orchestrator state written to runs/, plans/,
+          // .quickfix/, node_modules/, __pycache__, etc., bloating commit diffs with
+          // noise unrelated to the agent's actual work (smoke5c failure mode, issue #27).
+          // gitPathspecExcludes() mirrors the Python-side capture exclusion from
+          // worktree_reserved_paths.py so both sides stay in sync. See PR 2.
+          const excludes = gitPathspecExcludes();
+          execSync(
+            `git add -A -- . ${excludes.map(e => `'${e}'`).join(' ')}`,
+            { cwd: worktreePath, stdio: 'pipe' }
+          );
           execSync(
             `git commit -m "auto-commit uncommitted work from step ${step.stepNumber} (${agent.name})"`,
             { cwd: worktreePath, stdio: 'pipe', env: { ...process.env, GIT_TERMINAL_PROMPT: '0' } }

--- a/src/worktree-reserved-paths.ts
+++ b/src/worktree-reserved-paths.ts
@@ -1,0 +1,94 @@
+/**
+ * Reserved paths for per-step commit-level exclusion (issue #27 / PR 2).
+ *
+ * Mirrors benchmarks/swe-bench/evaluation-scripts/worktree_reserved_paths.py
+ * one-for-one so that commit-time exclusion (TS side) stays in parity with
+ * capture-time exclusion (Python side). If you update one, update the other.
+ *
+ * Three categories tracked separately so audit decisions stay legible:
+ *
+ *   ORCHESTRATOR_RESERVED_PATHS — paths this codebase writes to during normal
+ *   operation. Scraped from src/**\/*.ts. Update when a new code path starts
+ *   writing to a new top-level directory inside the worktree.
+ *
+ *   BUILD_ARTIFACT_RESERVED_PATHS — paths universal build tooling writes
+ *   (package managers, compilers, test runners, venv tools). Not
+ *   orchestrator-specific; reasonable to exclude from any commit regardless.
+ *
+ *   FILE_GLOB_EXCLUDES — pure file-glob patterns (not directory prefixes).
+ *   Appended separately from the directory dual-form expansion below.
+ *
+ * The consumer is gitPathspecExcludes(), which is called at the per-step
+ * commit site in swarm-orchestrator.ts. See the parity test in
+ * test/worktree-reserved-paths.test.ts for the cross-language invariant.
+ */
+
+export const ORCHESTRATOR_RESERVED_PATHS: ReadonlyArray<string> = [
+  // runDir tree — holds everything orchestrator-scoped:
+  //   .context/shared-context.json (per-step manifest)
+  //   .locks/ (git serialization locks)
+  //   worktrees/step-N/ (per-step isolated worktrees)
+  //   steps/step-N/share.md (transcripts)
+  //   session-state.json, metrics.json, cost-attribution.json
+  //   quality-gates/ (gate output)
+  // Excluding "runs" excludes every nested path; no need to list sub-dirs.
+  'runs',
+  // quick-fix-mode session scratch (src/quick-fix-mode.ts)
+  '.quickfix',
+  // PlanStorage default writes plan-*.json here when planDir is unset
+  // (src/plan-storage.ts)
+  'plans',
+];
+
+export const BUILD_ARTIFACT_RESERVED_PATHS: ReadonlyArray<string> = [
+  // Node
+  'node_modules',
+  // Python
+  '__pycache__',
+  '.venv',
+  'venv',
+  'env',
+  // JS build tools
+  '.next',
+  '.turbo',
+  '.cache',
+  // Generic build output
+  'dist',
+  'build',
+  // Test coverage
+  'coverage',
+];
+
+export const FILE_GLOB_EXCLUDES: ReadonlyArray<string> = [
+  '**/*.pyc',
+  '**/*.pyo',
+  '**/*.egg-info',
+  '**/*.egg-info/**',
+];
+
+/**
+ * Return git pathspec :(exclude) directives covering every reserved path.
+ *
+ * For each directory entry, emits both the top-level form (`:(exclude)runs`)
+ * and a tree glob (`:(exclude)runs/**`). Git requires both when the exclude
+ * should match the directory itself AND everything under it; the top-level
+ * form alone can miss deeply nested files on some git versions.
+ *
+ * Emission count: 14 directories × 2 (dual-form) + 4 file globs = 32 args.
+ * Matches Python's git_pathspec_excludes() output one-for-one.
+ *
+ * Consumers pass this list as trailing arguments to `git add` after a
+ * positive pathspec (typically `--`). Note: git add for commits does NOT
+ * need the `.` positive pathspec that capture uses; `git add -A` already
+ * stages the whole tree and the excludes suppress the reserved paths.
+ */
+export function gitPathspecExcludes(): string[] {
+  const directoryExcludes = [
+    ...ORCHESTRATOR_RESERVED_PATHS,
+    ...BUILD_ARTIFACT_RESERVED_PATHS,
+  ].flatMap(dir => [`:(exclude)${dir}`, `:(exclude)${dir}/**`]);
+
+  const globExcludes = FILE_GLOB_EXCLUDES.map(g => `:(exclude)${g}`);
+
+  return [...directoryExcludes, ...globExcludes];
+}

--- a/test/commit-reserved-paths.test.ts
+++ b/test/commit-reserved-paths.test.ts
@@ -1,0 +1,182 @@
+// Author: Bradley R. Kinnard
+import { strict as assert } from 'assert';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { gitPathspecExcludes } from '../src/worktree-reserved-paths';
+
+/**
+ * Create a temp git repo with both real files and files inside every reserved
+ * path category. Used by both the "bare add leaks" and "fixed add cleans" tests.
+ */
+function buildTempRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-commit-test-'));
+
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'Test',
+    GIT_AUTHOR_EMAIL: 'test@test.com',
+    GIT_COMMITTER_NAME: 'Test',
+    GIT_COMMITTER_EMAIL: 'test@test.com',
+    GIT_TERMINAL_PROMPT: '0',
+  };
+
+  execSync('git init', { cwd: dir, stdio: 'pipe', env: gitEnv });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe', env: gitEnv });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe', env: gitEnv });
+
+  // Create real source file — this SHOULD appear in every commit
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'src', 'real.ts'), 'export const x = 1;\n');
+
+  // Reserved: orchestrator runtime directories
+  fs.mkdirSync(path.join(dir, 'runs', 'swarm-abc'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'runs', 'swarm-abc', 'session-state.json'),
+    JSON.stringify({ runId: 'swarm-abc' })
+  );
+
+  fs.mkdirSync(path.join(dir, '.quickfix'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.quickfix', 'state.json'), '{}');
+
+  fs.mkdirSync(path.join(dir, 'plans'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'plans', 'plan-001.json'), '{}');
+
+  // Reserved: build artifacts
+  fs.mkdirSync(path.join(dir, 'node_modules', 'pkg'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'node_modules', 'pkg', 'index.js'), 'module.exports = {};\n');
+
+  fs.mkdirSync(path.join(dir, '__pycache__'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '__pycache__', 'foo.cpython-311.pyc'),
+    '# compiled python\n'
+  );
+
+  fs.mkdirSync(path.join(dir, '.venv', 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.venv', 'bin', 'python'), '#!/bin/sh\n');
+
+  fs.mkdirSync(path.join(dir, 'dist'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'dist', 'bundle.js'), 'bundled\n');
+
+  fs.mkdirSync(path.join(dir, 'coverage'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'coverage', 'lcov.info'), 'coverage data\n');
+
+  // Reserved: file-glob patterns — Python 3 puts .pyc in __pycache__ (already
+  // excluded above as a directory), but any stray .pyc in a subdirectory should
+  // also be suppressed. Root-level .pyc files are Python 2 artifacts and are not
+  // covered by **/*.pyc on all git versions; that edge case is out of scope.
+  fs.mkdirSync(path.join(dir, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'lib', 'util.pyc'), '# pyc in subdir\n');
+
+  // Create initial commit so HEAD exists (required for git add -A to work)
+  fs.writeFileSync(path.join(dir, '.gitignore'), '# placeholder\n');
+  execSync('git add .gitignore', { cwd: dir, stdio: 'pipe', env: gitEnv });
+  execSync('git commit -m "chore: init"', { cwd: dir, stdio: 'pipe', env: gitEnv });
+
+  return dir;
+}
+
+/**
+ * Return the list of files present in the most recent commit of the repo.
+ */
+function filesInLastCommit(dir: string): string[] {
+  const out = execSync('git diff-tree --no-commit-id -r --name-only HEAD', {
+    cwd: dir,
+    encoding: 'utf8',
+  }).trim();
+  return out ? out.split('\n') : [];
+}
+
+function cleanup(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup; test result is already recorded
+  }
+}
+
+describe('commit-level reserved-path exclusion: behavioral', () => {
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'Test',
+    GIT_AUTHOR_EMAIL: 'test@test.com',
+    GIT_COMMITTER_NAME: 'Test',
+    GIT_COMMITTER_EMAIL: 'test@test.com',
+    GIT_TERMINAL_PROMPT: '0',
+  };
+
+  it('bare git add -A leaks reserved paths into the commit (documents the bug)', () => {
+    const dir = buildTempRepo();
+    try {
+      execSync('git add -A', { cwd: dir, stdio: 'pipe', env: gitEnv });
+      execSync('git commit -m "auto: bare add"', { cwd: dir, stdio: 'pipe', env: gitEnv });
+
+      const files = filesInLastCommit(dir);
+
+      // Reserved paths SHOULD be present (this is the leak we're fixing)
+      const leakedReserved = files.filter(f =>
+        f.startsWith('runs/') ||
+        f.startsWith('.quickfix/') ||
+        f.startsWith('plans/') ||
+        f.startsWith('node_modules/') ||
+        f.startsWith('__pycache__/') ||
+        f.startsWith('.venv/') ||
+        f.startsWith('dist/') ||
+        f.startsWith('coverage/') ||
+        f.endsWith('.pyc') && !f.startsWith('__pycache__/')
+      );
+
+      assert.ok(
+        leakedReserved.length > 0,
+        `Expected bare git add -A to commit reserved-path files (leak), but none leaked.\n` +
+        `Files in commit: ${JSON.stringify(files)}`
+      );
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('git add -A with gitPathspecExcludes() omits all reserved paths from the commit', () => {
+    const dir = buildTempRepo();
+    try {
+      const excludes = gitPathspecExcludes();
+      // git add -A requires a positive pathspec when excludes are present.
+      // We use '.' as the positive pathspec alongside the :(exclude) directives.
+      execSync(
+        `git add -A -- . ${excludes.map(e => `'${e}'`).join(' ')}`,
+        { cwd: dir, stdio: 'pipe', env: gitEnv }
+      );
+      execSync('git commit -m "auto: excluded add"', { cwd: dir, stdio: 'pipe', env: gitEnv });
+
+      const files = filesInLastCommit(dir);
+
+      // src/real.ts MUST be committed
+      assert.ok(
+        files.includes('src/real.ts'),
+        `Expected src/real.ts in commit. Files: ${JSON.stringify(files)}`
+      );
+
+      // None of the reserved-path files should appear
+      const leaked = files.filter(f =>
+        f.startsWith('runs/') ||
+        f.startsWith('.quickfix/') ||
+        f.startsWith('plans/') ||
+        f.startsWith('node_modules/') ||
+        f.startsWith('__pycache__/') ||
+        f.startsWith('.venv/') ||
+        f.startsWith('dist/') ||
+        f.startsWith('coverage/') ||
+        f.endsWith('.pyc')
+      );
+
+      assert.strictEqual(
+        leaked.length,
+        0,
+        `Reserved-path files leaked into commit:\n  ${leaked.join('\n  ')}`
+      );
+    } finally {
+      cleanup(dir);
+    }
+  });
+});

--- a/test/worktree-reserved-paths.test.ts
+++ b/test/worktree-reserved-paths.test.ts
@@ -1,0 +1,191 @@
+// Author: Bradley R. Kinnard
+import { strict as assert } from 'assert';
+import { execSync, spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  ORCHESTRATOR_RESERVED_PATHS,
+  BUILD_ARTIFACT_RESERVED_PATHS,
+  FILE_GLOB_EXCLUDES,
+  gitPathspecExcludes,
+} from '../src/worktree-reserved-paths';
+
+// __dirname is dist/test/ at runtime; step up two levels to reach repo root
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PYTHON_FILE = path.join(
+  REPO_ROOT,
+  'benchmarks/swe-bench/evaluation-scripts/worktree_reserved_paths.py'
+);
+
+/**
+ * Extract the string contents of a Python tuple/list literal from source text.
+ * Handles multi-line tuples with inline comments by doing a line-by-line walk:
+ * 1. Find the line where NAME appears as an assignment (not in a docstring comment).
+ * 2. From there, accumulate lines until we see a line that closes the tuple/list.
+ * 3. Strip comments from each line, then collect quoted strings.
+ */
+function extractPythonTuple(src: string, name: string): string[] {
+  const lines = src.split('\n');
+
+  // Find the assignment line: must start with the name (ignoring leading spaces)
+  // and contain '=' and '(' or '['. Skip comment-only lines.
+  let startIdx = -1;
+  const assignRe = new RegExp(`^\\s*${name}\\s*[^=]*=\\s*[\\(\\[]`);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith('#')) continue;
+    if (assignRe.test(line)) {
+      startIdx = i;
+      break;
+    }
+  }
+
+  if (startIdx === -1) {
+    throw new Error(`Could not find assignment for ${name} in Python source`);
+  }
+
+  // Walk forward accumulating lines until we see a closing ) or ] on its own line
+  const bodyLines: string[] = [];
+  for (let i = startIdx; i < lines.length; i++) {
+    const raw = lines[i];
+    // Strip inline comment
+    const noComment = raw.replace(/#.*$/, '');
+    bodyLines.push(noComment);
+    // Check if this line closes the tuple: trimmed is just ')' or ']'
+    if (i > startIdx && /^\s*[\)\]]/.test(noComment)) {
+      break;
+    }
+  }
+
+  const body = bodyLines.join('\n');
+  const items: string[] = [];
+  const itemRe = /["']([^"'\n]+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = itemRe.exec(body)) !== null) {
+    items.push(m[1]);
+  }
+  return items;
+}
+
+describe('worktree-reserved-paths: cross-language parity', () => {
+  let pythonSrc: string;
+
+  before(() => {
+    assert.ok(
+      fs.existsSync(PYTHON_FILE),
+      `Python canonical file not found: ${PYTHON_FILE}`
+    );
+    pythonSrc = fs.readFileSync(PYTHON_FILE, 'utf8');
+  });
+
+  it('ORCHESTRATOR_RESERVED_PATHS matches Python ORCHESTRATOR_RESERVED_PATHS', () => {
+    const pyValues = extractPythonTuple(pythonSrc, 'ORCHESTRATOR_RESERVED_PATHS');
+    assert.deepStrictEqual(
+      Array.from(ORCHESTRATOR_RESERVED_PATHS),
+      pyValues,
+      `TS ORCHESTRATOR_RESERVED_PATHS does not match Python.\n` +
+      `  TS:  ${JSON.stringify(ORCHESTRATOR_RESERVED_PATHS)}\n` +
+      `  Py:  ${JSON.stringify(pyValues)}`
+    );
+  });
+
+  it('BUILD_ARTIFACT_RESERVED_PATHS matches Python BUILD_ARTIFACT_RESERVED_PATHS', () => {
+    const pyValues = extractPythonTuple(pythonSrc, 'BUILD_ARTIFACT_RESERVED_PATHS');
+    assert.deepStrictEqual(
+      Array.from(BUILD_ARTIFACT_RESERVED_PATHS),
+      pyValues,
+      `TS BUILD_ARTIFACT_RESERVED_PATHS does not match Python.\n` +
+      `  TS:  ${JSON.stringify(BUILD_ARTIFACT_RESERVED_PATHS)}\n` +
+      `  Py:  ${JSON.stringify(pyValues)}`
+    );
+  });
+
+  it('FILE_GLOB_EXCLUDES matches Python _FILE_GLOB_EXCLUDES', () => {
+    const pyValues = extractPythonTuple(pythonSrc, '_FILE_GLOB_EXCLUDES');
+    assert.deepStrictEqual(
+      Array.from(FILE_GLOB_EXCLUDES),
+      pyValues,
+      `TS FILE_GLOB_EXCLUDES does not match Python _FILE_GLOB_EXCLUDES.\n` +
+      `  TS:  ${JSON.stringify(FILE_GLOB_EXCLUDES)}\n` +
+      `  Py:  ${JSON.stringify(pyValues)}`
+    );
+  });
+
+  it('gitPathspecExcludes() output matches Python git_pathspec_excludes() output', () => {
+    // Run the Python function via subprocess and compare arrays element-by-element
+    const result = spawnSync(
+      'python3',
+      ['-c', `
+import sys, json
+sys.path.insert(0, '${path.join(REPO_ROOT, 'benchmarks/swe-bench/evaluation-scripts').replace(/\\/g, '\\\\')}')
+from worktree_reserved_paths import git_pathspec_excludes
+print(json.dumps(git_pathspec_excludes()))
+`],
+      { encoding: 'utf8' }
+    );
+
+    assert.strictEqual(
+      result.status,
+      0,
+      `Python subprocess failed:\n${result.stderr}`
+    );
+
+    const pyOutput: string[] = JSON.parse(result.stdout.trim());
+    const tsOutput = gitPathspecExcludes();
+
+    assert.deepStrictEqual(
+      tsOutput,
+      pyOutput,
+      `gitPathspecExcludes() output diverges from Python git_pathspec_excludes().\n` +
+      `  TS length: ${tsOutput.length}, Py length: ${pyOutput.length}\n` +
+      `  First mismatch at index: ${tsOutput.findIndex((v, i) => v !== pyOutput[i])}`
+    );
+  });
+});
+
+describe('worktree-reserved-paths: bounded-list invariants', () => {
+  it('ORCHESTRATOR_RESERVED_PATHS has at most 5 entries', () => {
+    assert.ok(
+      ORCHESTRATOR_RESERVED_PATHS.length <= 5,
+      `ORCHESTRATOR_RESERVED_PATHS has ${ORCHESTRATOR_RESERVED_PATHS.length} entries (limit: 5). ` +
+      `If this is a legitimate addition, update the bound in this test.`
+    );
+  });
+
+  it('BUILD_ARTIFACT_RESERVED_PATHS has at most 15 entries', () => {
+    assert.ok(
+      BUILD_ARTIFACT_RESERVED_PATHS.length <= 15,
+      `BUILD_ARTIFACT_RESERVED_PATHS has ${BUILD_ARTIFACT_RESERVED_PATHS.length} entries (limit: 15). ` +
+      `If this is a legitimate addition, update the bound in this test.`
+    );
+  });
+
+  it('FILE_GLOB_EXCLUDES has at most 6 entries', () => {
+    assert.ok(
+      FILE_GLOB_EXCLUDES.length <= 6,
+      `FILE_GLOB_EXCLUDES has ${FILE_GLOB_EXCLUDES.length} entries (limit: 6). ` +
+      `If this is a legitimate addition, update the bound in this test.`
+    );
+  });
+
+  it('gitPathspecExcludes() emits the expected number of args (14 dirs × 2 + 4 globs = 32)', () => {
+    const excludes = gitPathspecExcludes();
+    const expectedDirCount = ORCHESTRATOR_RESERVED_PATHS.length + BUILD_ARTIFACT_RESERVED_PATHS.length;
+    const expected = expectedDirCount * 2 + FILE_GLOB_EXCLUDES.length;
+    assert.strictEqual(
+      excludes.length,
+      expected,
+      `Expected ${expected} pathspec args, got ${excludes.length}`
+    );
+  });
+
+  it('every gitPathspecExcludes() entry starts with :(exclude)', () => {
+    const bad = gitPathspecExcludes().filter(e => !e.startsWith(':(exclude)'));
+    assert.strictEqual(
+      bad.length,
+      0,
+      `Entries missing :(exclude) prefix: ${JSON.stringify(bad)}`
+    );
+  });
+});


### PR DESCRIPTION
## Context

smoke5c demonstrated that bare `git add -A` at the per-step auto-commit site (swarm-orchestrator.ts:1535) staged everything inside the agent worktree: the full `runs/` tree, `node_modules/`, `__pycache__/`, `.venv/`, etc. These are orchestrator-internal writes, not agent work. They bloated per-step commits with noise unrelated to what the agent actually did, and caused diff inflation that blocked downstream verification. See #27 (closed) for the 31.7 MB smoke3 failure mode; this PR addresses the commit-layer equivalent.

## Approach

Commit-time pathspec exclusion at the orchestrator layer, mirroring PR 1 / #33's capture-time exclusion at the SWE-bench-eval layer. The same set of paths needs to be excluded at both layers; a single source of truth on each side with a cross-language parity test enforces that they stay in sync.

## Structural decision: option (a), three-category mirror

New file [src/worktree-reserved-paths.ts](src/worktree-reserved-paths.ts) exports three constants mirroring [benchmarks/swe-bench/evaluation-scripts/worktree_reserved_paths.py](benchmarks/swe-bench/evaluation-scripts/worktree_reserved_paths.py) exactly:

| Constant | Entries |
|---|---|
| `ORCHESTRATOR_RESERVED_PATHS` | `runs`, `.quickfix`, `plans` |
| `BUILD_ARTIFACT_RESERVED_PATHS` | `node_modules`, `__pycache__`, `.venv`, `venv`, `env`, `.next`, `.turbo`, `.cache`, `dist`, `build`, `coverage` |
| `FILE_GLOB_EXCLUDES` | `**/*.pyc`, `**/*.pyo`, `**/*.egg-info`, `**/*.egg-info/**` |

`gitPathspecExcludes()` emits dual-form `:(exclude)dir` + `:(exclude)dir/**` for every directory entry: 14 directories x 2 + 4 file globs = **32 pathspec args**. Same emission logic as Python's `git_pathspec_excludes()`.

The parity test was written before the call-site modification. During test authorship, two transcription errors in the initial spec (corrupted glob forms and `pycache` vs `__pycache__`) were caught by direct diff against the Python source. The TS constants are the corrected values; the parity test now enforces ongoing alignment.

## Scope audit results

`grep -rn "git add -A" src/` returns exactly 4 matches:

| Site | Function | Trigger | In scope |
|---|---|---|---|
| swarm-orchestrator.ts:1535 | per-step auto-commit | every step, target-mode | **yes** |
| worktree-manager.ts:45 | `createAgentWorktree()` | no-HEAD fallback on init | no |
| worktree-manager.ts:296 | `ensureInitialCommit()` | once per run, empty repo | no |
| worktree-manager.ts:335 | `ensureOwnGitRepo()` | repo bootstrap only | no |

PR 2 modifies exactly one call site.

## What this does NOT address

- Root-level `*.pyc` files: `**/*.pyc` does not match files directly in the worktree root on all git versions. This is a Python 2 artifact pattern; Python 3 writes to `__pycache__/` which the directory exclusion already covers. Documented in test comments.
- The three init-only `git add -A` sites in worktree-manager.ts. Init commits include all files by design.

## Test plan

**test/worktree-reserved-paths.test.ts:**
- Parity, category-by-category: TS constants vs. Python source text (line-by-line extractor to handle comments containing parentheses).
- Subprocess parity: `gitPathspecExcludes()` output compared against `git_pathspec_excludes()` output from Python subprocess. Catches helper-function drift independent of the constants.
- Bounded-list invariants: <= 5, <= 15, <= 6 per category. Requires conscious test update for any non-trivial addition.
- Emission count: 32 args, all prefixed `:(exclude)`.

**test/commit-reserved-paths.test.ts:**
- Behavioral test 1: bare `git add -A` commits reserved-path files (documents the bug as a self-updating spec; if the leak ever disappears without this fix, this test fails and forces re-examination).
- Behavioral test 2: `git add -A` with `gitPathspecExcludes()` produces a commit containing `src/real.ts` and none of `runs/`, `.quickfix/`, `plans/`, `node_modules/`, `__pycache__/`, `.venv/`, `dist/`, `coverage/`, or `*.pyc` files in subdirectories.

## Results

`npm run lint`: clean. `npm test`: 1497 passing, 6 pending, 0 failing.