### PR TITLE
feat(swe-bench): --keep-workdir flag for post-run workspace inspection

### DIFF
--- a/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
+++ b/benchmarks/swe-bench/evaluation-scripts/run_swebench.py
@@ -17,10 +17,12 @@ Environment variables:
   TASK_TIMEOUT_SECONDS   Per-task timeout (default: 900)
 """
 
+import argparse
 import fnmatch
 import glob
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -894,15 +896,35 @@ def run_tests_dispatch(task: dict, repo_dir: Path) -> dict:
     return result
 
 
-def evaluate_tasks():
-    """Main evaluation loop."""
+def _print_workspace_preserved(workdir: Path) -> None:
+    """Print the preserved workspace path and ready-to-paste diagnostic commands."""
+    print(f"\n{'='*60}")
+    print(f"Workspace preserved at: {workdir}")
+    print("Diagnostic commands:")
+    print(f"  cd {workdir}/<instance_id>")
+    print("  git status --short | wc -l")
+    print("  git diff HEAD --stat | tail -30")
+    print("  git diff HEAD --name-only | awk -F/ '{print $1}' | sort | uniq -c | sort -rn | head -20")
+    print("  git diff HEAD --name-only | awk -F. '{print $NF}' | sort | uniq -c | sort -rn | head -20")
+    print("  git diff HEAD --numstat | sort -rn | head -10")
+    print(f"{'='*60}")
+
+
+def evaluate_tasks(*, keep_workdir: bool = False) -> dict:
+    """Main evaluation loop.
+
+    Args:
+        keep_workdir: When True, the temporary workspace directory is NOT
+            deleted after the run. The path is printed prominently with
+            ready-to-paste diagnostic commands. Default is False (clean up
+            on exit, matching the original behavior).
+    """
     tasks = load_tasks()
     results = []
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
-    with tempfile.TemporaryDirectory(prefix="swebench-") as tmpdir:
-        workdir = Path(tmpdir)
-
+    workdir = Path(tempfile.mkdtemp(prefix="swebench-"))
+    try:
         for task in tqdm(tasks, desc="Evaluating"):
             instance_id = task["instance_id"]
             print(f"\n{'='*60}")
@@ -941,6 +963,11 @@ def evaluate_tasks():
             results.append(task_result)
             print(f"  → {'RESOLVED' if task_result['resolved'] else 'FAILED'}"
                   f" ({run_result['elapsed_seconds']:.1f}s)")
+    finally:
+        if keep_workdir:
+            _print_workspace_preserved(workdir)
+        else:
+            shutil.rmtree(workdir, ignore_errors=True)
 
     # Write results
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -980,4 +1007,19 @@ def evaluate_tasks():
 
 
 if __name__ == "__main__":
-    evaluate_tasks()
+    parser = argparse.ArgumentParser(
+        description="SWE-bench evaluation runner for swarm-orchestrator."
+    )
+    parser.add_argument(
+        "--keep-workdir",
+        action="store_true",
+        default=False,
+        help=(
+            "Preserve the temporary workspace directory after the run instead of "
+            "deleting it. The path is printed at the end with ready-to-paste "
+            "diagnostic commands. Useful for post-run inspection of git state. "
+            "Default: off (workdir is deleted on exit)."
+        ),
+    )
+    args = parser.parse_args()
+    evaluate_tasks(keep_workdir=args.keep_workdir)

--- a/benchmarks/swe-bench/tests/test_keep_workdir.py
+++ b/benchmarks/swe-bench/tests/test_keep_workdir.py
@@ -1,0 +1,148 @@
+"""Behavioral tests for the --keep-workdir flag (PR 3).
+
+Verify that:
+  1. Without the flag, the workspace directory is removed after evaluate_tasks returns.
+  2. With the flag, the workspace directory survives on disk after the call.
+
+These tests mock the inner loop so no network I/O or agent invocation occurs.
+
+Run:
+  python3 -m pytest benchmarks/swe-bench/tests/test_keep_workdir.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "run_swebench",
+    _HERE.parent / "evaluation-scripts" / "run_swebench.py",
+)
+_module = importlib.util.module_from_spec(_SPEC)
+try:
+    _SPEC.loader.exec_module(_module)  # type: ignore[union-attr]
+except Exception as exc:  # pragma: no cover
+    pytest.skip(
+        f"run_swebench.py did not import cleanly: {exc}", allow_module_level=True
+    )
+
+evaluate_tasks = _module.evaluate_tasks
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_TASK = {
+    "instance_id": "test__repo-1",
+    "repo": "test/repo",
+    "base_commit": "abc123def456",
+    "problem_statement": "Fix the bug.",
+    "hints_text": "",
+    "created_at": "2024-01-01T00:00:00Z",
+    "version": "1.0",
+    "FAIL_TO_PASS": "[]",
+    "PASS_TO_PASS": "[]",
+    "environment_setup_commit": "abc123def456",
+}
+
+_FAKE_RUN = {"elapsed_seconds": 1.0, "returncode": 0, "stdout": "", "stderr": ""}
+_FAKE_TEST = {"passed": False, "reason": "test_stub"}
+
+
+def _make_mocks(captured_workdir: list[Path]):
+    """Return a dict of patches that capture the workdir path without doing any I/O."""
+
+    def fake_load_tasks():
+        return [_FAKE_TASK]
+
+    def fake_checkout_repo(task, workdir):
+        repo_dir = workdir / task["instance_id"]
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        # Record the workdir so tests can check whether it survived.
+        captured_workdir.append(workdir)
+        return repo_dir
+
+    def fake_run_orchestrator(repo_dir, problem_statement):
+        return _FAKE_RUN
+
+    def fake_run_tests_dispatch(task, repo_dir):
+        return _FAKE_TEST
+
+    def fake_json_dump(obj, fp, **kwargs):
+        pass
+
+    return {
+        "run_swebench.load_tasks": fake_load_tasks,
+        "run_swebench.checkout_repo": fake_checkout_repo,
+        "run_swebench.run_orchestrator": fake_run_orchestrator,
+        "run_swebench.run_tests_dispatch": fake_run_tests_dispatch,
+        "run_swebench.RESULTS_DIR": Path("/tmp"),
+        # Prevent actually writing a results JSON.
+        "json.dump": fake_json_dump,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_workdir_cleaned_up_by_default():
+    """Without --keep-workdir, the workspace directory is removed after the run."""
+    captured: list[Path] = []
+    patches = _make_mocks(captured)
+
+    with (
+        patch.object(_module, "load_tasks", patches["run_swebench.load_tasks"]),
+        patch.object(_module, "checkout_repo", patches["run_swebench.checkout_repo"]),
+        patch.object(_module, "run_orchestrator", patches["run_swebench.run_orchestrator"]),
+        patch.object(_module, "run_tests_dispatch", patches["run_swebench.run_tests_dispatch"]),
+        patch.object(_module, "RESULTS_DIR", Path("/tmp")),
+        patch("json.dump", patches["json.dump"]),
+    ):
+        evaluate_tasks(keep_workdir=False)
+
+    assert len(captured) == 1, "checkout_repo should have been called once"
+    workdir = captured[0]
+    assert not workdir.exists(), (
+        f"Workdir {workdir} should have been deleted when keep_workdir=False"
+    )
+
+
+def test_workdir_preserved_with_flag(capsys):
+    """With keep_workdir=True, the workspace directory survives and its path is printed."""
+    captured: list[Path] = []
+    patches = _make_mocks(captured)
+
+    try:
+        with (
+            patch.object(_module, "load_tasks", patches["run_swebench.load_tasks"]),
+            patch.object(_module, "checkout_repo", patches["run_swebench.checkout_repo"]),
+            patch.object(_module, "run_orchestrator", patches["run_swebench.run_orchestrator"]),
+            patch.object(_module, "run_tests_dispatch", patches["run_swebench.run_tests_dispatch"]),
+            patch.object(_module, "RESULTS_DIR", Path("/tmp")),
+            patch("json.dump", patches["json.dump"]),
+        ):
+            evaluate_tasks(keep_workdir=True)
+
+        assert len(captured) == 1, "checkout_repo should have been called once"
+        workdir = captured[0]
+        assert workdir.exists(), (
+            f"Workdir {workdir} should have been preserved when keep_workdir=True"
+        )
+
+        out = capsys.readouterr().out
+        assert str(workdir) in out, (
+            "The preserved workspace path should be printed to stdout"
+        )
+    finally:
+        # Clean up the preserved workdir so the test doesn't litter.
+        if captured and captured[0].exists():
+            import shutil
+            shutil.rmtree(captured[0], ignore_errors=True)


### PR DESCRIPTION
## Summary

PR 3 in the SWE-bench diagnostic sequence. Scope: workspace persistence only.

The 31 MB diff-size failure in smoke6 could not be diagnosed because `tempfile.TemporaryDirectory` deletes the workspace on process exit. There was nothing to inspect. This PR makes it inspectable.

## Changes

**`benchmarks/swe-bench/evaluation-scripts/run_swebench.py`**
- Adds `argparse` to the `__main__` block; `--keep-workdir` flag (default off)
- Replaces `with tempfile.TemporaryDirectory(...)` with `mkdtemp` + `shutil.rmtree` inside a `try/finally`, so default behavior is identical
- Adds `_print_workspace_preserved()`: prints the workspace path and ready-to-paste git diagnostic commands when the flag is set
- `evaluate_tasks()` gains a keyword-only `keep_workdir: bool = False` parameter

**`benchmarks/swe-bench/tests/test_keep_workdir.py`** (new)
- `test_workdir_cleaned_up_by_default`: verifies the directory is gone after `evaluate_tasks(keep_workdir=False)`
- `test_workdir_preserved_with_flag`: verifies the directory exists and path appears in stdout after `evaluate_tasks(keep_workdir=True)`
- Both tests mock the inner loop (no network, no agent), follow the same `pytest.skip`-on-missing-`datasets` pattern as existing test files

## What this does NOT change

- Default cleanup behavior (CI sweeps are unaffected)
- `capture_agent_diff` or any exclude lists
- The 31 MB root cause (fix comes after diagnostic data is collected)

## Next steps after merge

Run smoke7 with `--keep-workdir`. Navigate to the preserved workspace and run the six diagnostic commands. That output determines whether the 31 MB is category A/B/C.