### PR TITLE
chore(release): bump version to 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swarm-orchestrator",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Contract-first AI coding swarm with hash-chained evidence. Compiles a goal into typed obligations, races persona candidates per obligation in a single cached inference session, verifies before commit, and logs every action in an append-only ledger.",
   "main": "dist/src/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

Bumps `package.json` version from 8.0.0 to 8.0.1 so the AST/extractor fix from PR #41 (commit 1211e11, merged in 6766491) can be tagged as an installable release. The v8.0.0 tag was cut on commit db820f5 — before #41 landed — so anyone checking out the v8.0.0 tag still sees the pre-fix code that documents the Anthropic-extractor / substring-signature / regex-import caveats as known limitations.

After this PR merges, I'll tag v8.0.1 on the merge commit so:
- `git checkout v8.0.1` includes the AST verifiers + extractor fix
- A future `npm publish` from that tag will ship the fix

No code changes here — release-marker commit only.

## Test plan

- [ ] CI typecheck passes
- [ ] CI lint passes
- [ ] CI build-and-test passes on Node 20 and Node 22
- [ ] CI security-audit passes
- [ ] CI synthetic-falsification-calibration passes
- [ ] CI docker build passes
- [ ] After merge: tag v8.0.1 on the resulting merge commit and push the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)