### PR TITLE
fix: resolve six pre-existing test failures + add run-wrapper coverage

### DIFF
--- a/src/cli/v8/run-wrapper.ts
+++ b/src/cli/v8/run-wrapper.ts
@@ -6,6 +6,19 @@ import { handleRun } from './run-handler';
 const logger = getLogger('cli:v8:run-wrapper');
 
 /**
+ * Test seam: the wrapper delegates `compile` and `run` through this object
+ * so unit tests can substitute fakes without spawning the real handlers.
+ * Production callers pass nothing; the defaults wire to the real
+ * `handleCompile` / `handleRun`.
+ */
+export interface RunV8Deps {
+  readonly handleCompile: (argv: string[]) => Promise<number>;
+  readonly handleRun: (argv: string[]) => Promise<number>;
+}
+
+const DEFAULT_DEPS: RunV8Deps = { handleCompile, handleRun };
+
+/**
  * Entry point for `swarm run` under v8 default-dispatch (impl guide §12
  * line 275: "after Phase 4, v8 becomes opt-out: default switches to v8,
  * `--v6` flag preserves old behavior").
@@ -30,7 +43,10 @@ const logger = getLogger('cli:v8:run-wrapper');
  *   the run pass. The convenience pass-throughs (`--session`,
  *   `--no-deterministic`, etc.) are recognized as v8-run flags.
  */
-export async function handleRunV8(argv: string[]): Promise<number> {
+export async function handleRunV8(
+  argv: string[],
+  deps: RunV8Deps = DEFAULT_DEPS,
+): Promise<number> {
   const split = splitArgv(argv);
 
   if (split.goal === null) {
@@ -60,7 +76,7 @@ export async function handleRunV8(argv: string[]): Promise<number> {
 
   // The compile step writes to `<out>/<contract-id>/`. We re-derive the
   // path from the manifest immediately after compile.
-  const compileExit = await handleCompile(compileArgv);
+  const compileExit = await deps.handleCompile(compileArgv);
   if (compileExit !== 0) return compileExit;
 
   const contractDir = findLatestContractDir(contractsParent);
@@ -70,8 +86,19 @@ export async function handleRunV8(argv: string[]): Promise<number> {
   }
 
   const runArgv: string[] = [contractDir, '--repo-root', repoRoot, ...split.runPassthrough];
-  return handleRun(runArgv);
+  return deps.handleRun(runArgv);
 }
+
+/**
+ * Test-only re-exports of the internal helpers. The names are prefixed
+ * with `__` so that consumers reading public API surface skip them; the
+ * runtime values are the same functions used internally.
+ */
+export const __testing = {
+  splitArgv: (argv: string[]) => splitArgv(argv),
+  findLatestContractDir: (parent: string) => findLatestContractDir(parent),
+  requireValue: (argv: string[], index: number, flag: string) => requireValue(argv, index, flag),
+};
 
 interface SplitArgv {
   goal: string | null;

--- a/src/verification/source-locations.ts
+++ b/src/verification/source-locations.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 
 export interface SourceLocation {
@@ -11,11 +12,43 @@ function normalizeSlashes(value: string): string {
   return value.replace(/\\/g, '/');
 }
 
-function normalizeLocationPath(rawPath: string, repoPath: string): string | undefined {
+/**
+ * Resolve symlinks in `value` if it exists on disk; otherwise return the
+ * input unchanged. Defends against the macOS `/var` -> `/private/var`
+ * divergence: Node stack traces contain the realpath form, but callers
+ * usually hand us the un-resolved tmpdir form, and `path.relative` between
+ * the two produces a `../`-prefixed string that downstream filters drop.
+ */
+function tryRealpath(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeLocationPath(
+  rawPath: string,
+  repoPath: string,
+  repoPathReal: string,
+): string | undefined {
   const trimmed = rawPath.replace(/^[([]/, '').replace(/[),\]]$/, '');
-  const relative = path.isAbsolute(trimmed)
-    ? path.relative(repoPath, trimmed)
-    : trimmed.replace(/^\.\//, '');
+  let relative: string;
+  if (path.isAbsolute(trimmed)) {
+    const trimmedReal = tryRealpath(trimmed);
+    const candidates = [
+      path.relative(repoPath, trimmed),
+      path.relative(repoPathReal, trimmed),
+      path.relative(repoPath, trimmedReal),
+      path.relative(repoPathReal, trimmedReal),
+    ];
+    const inside = candidates.find(
+      (c) => c !== '' && !c.startsWith('..' + path.sep) && c !== '..',
+    );
+    relative = inside ?? candidates[0] ?? trimmed;
+  } else {
+    relative = trimmed.replace(/^\.\//, '');
+  }
   const normalized = normalizeSlashes(relative);
   if (normalized === '' || normalized.startsWith('../') || normalized === '..') {
     return undefined;
@@ -46,12 +79,13 @@ export function extractSourceLocations(
 ): SourceLocation[] {
   const locations: SourceLocation[] = [];
   const seen = new Set<string>();
+  const repoPathReal = tryRealpath(repoPath);
 
   for (const match of output.matchAll(SOURCE_LOCATION_RE)) {
     const rawPath = match[1];
     const rawLine = match[2];
     if (!rawPath || !rawLine) continue;
-    const filePath = normalizeLocationPath(rawPath, repoPath);
+    const filePath = normalizeLocationPath(rawPath, repoPath, repoPathReal);
     const line = Number.parseInt(rawLine, 10);
     if (!filePath || !Number.isInteger(line) || line < 1) continue;
     if (!matchesCandidate(filePath, candidateFiles)) continue;

--- a/src/verifier/outcome-checks.ts
+++ b/src/verifier/outcome-checks.ts
@@ -345,13 +345,16 @@ function detectTestCommand(workdir: string, workingDir: string): string | null {
   //     conftest.py).
   //   - --ignore paths prevent pytest from descending into orchestrator
   //     artifact trees whose own conftest.py would re-register options.
+  //     pytest 8.x accepts only paths relative to the current working
+  //     directory for --ignore; absolute paths are silently ignored, which
+  //     pre-fix caused the parent-worktree conftest to be loaded anyway.
+  //     The verifier always invokes pytest with `cwd: workdir`, so the
+  //     ignore arguments are intentionally relative.
   const pytestCmd = () => {
     const py = resolvePythonBinary(workdir, workingDir);
-    const runsDir = path.join(workdir, 'runs');
-    const swarmDir = path.join(workdir, '.swarm');
     return (
       `${py} -m pytest --rootdir="${workdir}" ` +
-      `--ignore="${runsDir}" --ignore="${swarmDir}"`
+      `--ignore=runs --ignore=.swarm`
     );
   };
 

--- a/test/cli/v8/run-wrapper.test.ts
+++ b/test/cli/v8/run-wrapper.test.ts
@@ -1,0 +1,211 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { handleRunV8, __testing } from '../../../src/cli/v8/run-wrapper';
+
+/**
+ * Unit tests for `handleRunV8` plus its argv-splitting and contract-dir
+ * discovery helpers. The test seam (`RunV8Deps`) lets us exercise the
+ * orchestration logic without spawning the real compile/run handlers.
+ */
+
+const { splitArgv, findLatestContractDir, requireValue } = __testing;
+
+describe('cli/v8/run-wrapper splitArgv', () => {
+  it('extracts every recognized compile-relevant flag from argv', () => {
+    const split = splitArgv([
+      '--goal',
+      'add a greet function',
+      '--repo-root',
+      '/tmp/repo',
+      '--extractor',
+      'anthropic',
+      '--api-key',
+      'sk-test',
+      '--model',
+      'claude-opus-4-7',
+      '--temperature',
+      '0.3',
+      '--session',
+      'session-x',
+    ]);
+    assert.equal(split.goal, 'add a greet function');
+    assert.equal(split.repoRoot, '/tmp/repo');
+    assert.equal(split.extractor, 'anthropic');
+    assert.equal(split.apiKey, 'sk-test');
+    assert.equal(split.model, 'claude-opus-4-7');
+    assert.equal(split.temperature, 0.3);
+    // --repo-root, --api-key, --model still pass through to the run step.
+    assert.deepEqual(split.runPassthrough, [
+      '--repo-root',
+      '/tmp/repo',
+      '--api-key',
+      'sk-test',
+      '--model',
+      'claude-opus-4-7',
+      '--session',
+      'session-x',
+    ]);
+  });
+
+  it('returns null fields for absent flags and routes unknown flags through to runPassthrough', () => {
+    const split = splitArgv(['--no-deterministic', '--cost-cap', '5']);
+    assert.equal(split.goal, null);
+    assert.equal(split.repoRoot, null);
+    assert.equal(split.extractor, null);
+    assert.equal(split.apiKey, null);
+    assert.equal(split.model, null);
+    assert.equal(split.temperature, null);
+    assert.deepEqual(split.runPassthrough, ['--no-deterministic', '--cost-cap', '5']);
+  });
+
+  it('throws when --temperature is not a finite number', () => {
+    assert.throws(() => splitArgv(['--temperature', 'not-a-number']), /invalid --temperature/);
+  });
+
+  it('requireValue rejects flags whose value is missing or starts with --', () => {
+    assert.throws(() => requireValue(['--goal'], 1, '--goal'), /requires a value/);
+    assert.throws(
+      () => requireValue(['--goal', '--repo-root'], 1, '--goal'),
+      /requires a value/,
+    );
+    assert.equal(requireValue(['--goal', 'real value'], 1, '--goal'), 'real value');
+  });
+});
+
+describe('cli/v8/run-wrapper findLatestContractDir', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'run-wrapper-test-')));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when the parent directory does not exist', () => {
+    const missing = path.join(tmpDir, 'does-not-exist');
+    assert.equal(findLatestContractDir(missing), null);
+  });
+
+  it('returns null when the parent directory is empty', () => {
+    assert.equal(findLatestContractDir(tmpDir), null);
+  });
+
+  it('returns the only contract dir when there is exactly one', () => {
+    const only = path.join(tmpDir, 'contract-1');
+    fs.mkdirSync(only);
+    assert.equal(findLatestContractDir(tmpDir), only);
+  });
+
+  it('returns the most recently mtimed contract dir when multiple exist', () => {
+    const older = path.join(tmpDir, 'older');
+    const newer = path.join(tmpDir, 'newer');
+    fs.mkdirSync(older);
+    fs.mkdirSync(newer);
+    // Force older to have an older mtime regardless of fs resolution.
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(older, past, past);
+    assert.equal(findLatestContractDir(tmpDir), newer);
+  });
+
+  it('ignores non-directory entries', () => {
+    fs.writeFileSync(path.join(tmpDir, 'stray-file.json'), '{}');
+    const dir = path.join(tmpDir, 'real-contract');
+    fs.mkdirSync(dir);
+    assert.equal(findLatestContractDir(tmpDir), dir);
+  });
+});
+
+describe('cli/v8/run-wrapper handleRunV8', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'run-wrapper-handle-')));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns exit code 1 when --goal is missing', async () => {
+    let compileCalled = false;
+    let runCalled = false;
+    const exit = await handleRunV8([], {
+      handleCompile: async () => {
+        compileCalled = true;
+        return 0;
+      },
+      handleRun: async () => {
+        runCalled = true;
+        return 0;
+      },
+    });
+    assert.equal(exit, 1);
+    assert.equal(compileCalled, false, 'compile must not run without --goal');
+    assert.equal(runCalled, false, 'run must not run without --goal');
+  });
+
+  it('forwards compile failure exit code without invoking run', async () => {
+    let runCalled = false;
+    const exit = await handleRunV8(['--goal', 'do something', '--repo-root', tmpDir], {
+      handleCompile: async () => 7,
+      handleRun: async () => {
+        runCalled = true;
+        return 0;
+      },
+    });
+    assert.equal(exit, 7);
+    assert.equal(runCalled, false, 'run must not be called after compile failure');
+  });
+
+  it('returns 1 when compile succeeds but no contract directory is produced', async () => {
+    const exit = await handleRunV8(['--goal', 'do something', '--repo-root', tmpDir], {
+      handleCompile: async () => 0,
+      handleRun: async () => 0,
+    });
+    assert.equal(exit, 1);
+  });
+
+  it('routes the discovered contract dir into the run step and returns its exit code', async () => {
+    const compileArgsCaptured: string[] = [];
+    let runArgvCaptured: string[] = [];
+    let runHandlerCalled = false;
+    const exit = await handleRunV8(
+      [
+        '--goal',
+        'add greet',
+        '--repo-root',
+        tmpDir,
+        '--extractor',
+        'anthropic',
+        '--no-deterministic',
+      ],
+      {
+        handleCompile: async (argv) => {
+          compileArgsCaptured.push(...argv);
+          // Simulate the compile-handler writing a contract dir.
+          const contractsParent = path.join(tmpDir, '.swarm', 'contracts');
+          fs.mkdirSync(contractsParent, { recursive: true });
+          fs.mkdirSync(path.join(contractsParent, 'contract-abc'));
+          return 0;
+        },
+        handleRun: async (argv) => {
+          runArgvCaptured = argv;
+          runHandlerCalled = true;
+          return 2;
+        },
+      },
+    );
+
+    assert.equal(exit, 2, 'wrapper must return run-handler exit code');
+    assert.ok(compileArgsCaptured.includes('add greet'));
+    assert.ok(compileArgsCaptured.includes('--extractor'));
+    assert.ok(compileArgsCaptured.includes('anthropic'));
+    assert.ok(runHandlerCalled, 'run handler must have been called');
+    assert.equal(runArgvCaptured[0], path.join(tmpDir, '.swarm', 'contracts', 'contract-abc'));
+    assert.ok(runArgvCaptured.includes('--no-deterministic'), 'unknown flag passed through');
+  });
+});

--- a/test/plan-files.test.ts
+++ b/test/plan-files.test.ts
@@ -28,7 +28,10 @@ describe('plan-files', () => {
 
   beforeEach(() => {
     originalCwd = process.cwd();
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-files-'));
+    // realpathSync resolves the macOS /var -> /private/var symlink so the
+    // path stored here matches what process.cwd() / savePlanFile compute;
+    // otherwise direct path-equality assertions diverge on Darwin.
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'plan-files-')));
     process.chdir(tmpDir);
   });
 

--- a/test/worktree-manager.test.ts
+++ b/test/worktree-manager.test.ts
@@ -9,7 +9,11 @@ describe('WorktreeManager', () => {
   let tempDir: string;
 
   beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'worktree-mgr-test-'));
+    // realpathSync resolves the macOS /var -> /private/var symlink so the
+    // path stored here matches what `git rev-parse --show-toplevel` and
+    // similar tools report; otherwise direct string comparisons against
+    // tool output diverge on Darwin.
+    tempDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'worktree-mgr-test-')));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Resolves the items from a recent audit that apply directly to `main` — the six pre-existing test failures + the self-gate's missing `run-wrapper.ts` test coverage. The audit also identified Phase 1 falsification-adapter issues; those depend on infrastructure that lives only on `feat/adapter-reintegration-v8` and are intentionally **not** included here.

### What's fixed

- **Differential-gate scope-fallback** (`src/verification/source-locations.ts`): macOS `/var` vs `/private/var` symlink divergence caused `path.relative` to produce `../`-prefixed paths that the location extractor filtered out; `commandFinding()` then fell through to `summaryFinding()`. Fix: realpath both sides before computing relative form. Eliminates 2 failing tests.
- **pytest `--slow` option collision** (`src/verifier/outcome-checks.ts`): pytest 8.x silently ignores absolute-path forms of `--ignore`. Fix: pass `--ignore=runs --ignore=.swarm` as relative paths (the verifier already runs pytest with `cwd: workdir`). Eliminates 1 failing test in the rootdir-isolation regression suite.
- **macOS realpath in test fixtures** (`test/plan-files.test.ts`, `test/worktree-manager.test.ts`): wrap `mkdtempSync` output in `fs.realpathSync` at test setup so subsequent path-equality assertions use the canonical form. Eliminates 3 failing tests.
- **`run-wrapper.ts` test coverage** (`src/cli/v8/run-wrapper.ts`, `test/cli/v8/run-wrapper.test.ts`): adds a small `RunV8Deps` injection seam (default behavior unchanged) and a unit test file covering `splitArgv`, `findLatestContractDir`, `requireValue`, and `handleRunV8` happy/error paths. Clears the self-gate's `test-coverage` finding.

### What's *not* in this PR

The Phase 1 falsification-adapter audit items (baseline predicate check, dev-gate snapshot pinning, codex stderr `Error.cause`, dev-gate resume support, cost-attribution auth-method split, codex CLI canary) all touch code that lives only on `feat/adapter-reintegration-v8`. They'll merge to main alongside that branch when it lands. See `evidence/2026-05-09-tool-limitations-resolved/summary.md` on `feat/adapter-reintegration-v8` for the full audit response.

## Test plan

- [x] `npm run typecheck` → clean
- [x] `npm run lint` → clean
- [x] `npm test` → **1989 passing, 8 pending, 0 failing** (was 1970 / 8 / 6 on `main` immediately before this PR)
- [x] `node dist/src/cli.js gates .` → exit 0, `test-coverage: 0 issue(s)`
- [ ] CI on this PR passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)