### PR TITLE
feat(population): workspace snapshot + ARIES-style rollback for falsified obligations

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ Reference: [`docs/configuration.md`](docs/configuration.md), config precedence i
 
 - **Tournament mode does not stream.** `--mode tournament` plus `--forbid-import`
   skips the streaming abort; streaming verification is `--mode single` only.
-- **Post-merge failure does not auto-rollback.** The run is marked failed;
-  per-obligation worktree snapshots are post-v8.0.
+- **Cleanup.** Per-obligation snapshot sidecars under `.swarm/snapshots/<run-id>/`
+  are written before each apply and not pruned at end of run; remove them when
+  reclaiming disk space.
 - **`--cost-cap` is enforced post-obligation, not mid-call.** Cumulative spend is
   checked at the end of each obligation against estimated Sonnet 4 pricing.
 - **Bandit dispatch is not built (Phase 5).** Codex and Copilot have disjoint

--- a/src/cli/v8/index.ts
+++ b/src/cli/v8/index.ts
@@ -2,6 +2,7 @@ import { getLogger } from '../../logger';
 import { handleCompile } from './compile-handler';
 import { handleResume } from './resume-handler';
 import { handleRun } from './run-handler';
+import { handleStats } from './stats-handler';
 
 const logger = getLogger('cli:v8');
 
@@ -23,6 +24,8 @@ export async function handleV8Command(argv: string[]): Promise<number> {
       return handleRun(rest);
     case 'resume':
       return handleResume(rest);
+    case 'stats':
+      return handleStats(rest);
     case undefined:
     case '--help':
     case '-h':
@@ -44,6 +47,7 @@ function printV8Usage(): void {
       '  compile <goal>   compile a natural-language goal into a contract',
       '  run <contract>   run a compiled contract',
       '  resume <run-id>  resume a partially-completed run',
+      '  stats <run-id>   aggregate diagnostic counts from a run ledger',
       '',
       'For per-subcommand flags, see `swarm v8 <subcommand> --help`.',
       '',

--- a/src/cli/v8/run-handler.ts
+++ b/src/cli/v8/run-handler.ts
@@ -172,6 +172,7 @@ export async function handleRun(
     registry,
     session,
     ledger,
+    runId,
     mode: flags.mode,
     preGeneration: flags.preGeneration,
     postMerge: flags.postMerge,

--- a/src/cli/v8/stats-handler.ts
+++ b/src/cli/v8/stats-handler.ts
@@ -1,0 +1,222 @@
+/**
+ * `swarm v8 stats <run-id>` aggregates a run's ledger and prints
+ * diagnostic counts. Read-only; never modifies the ledger or workspace.
+ *
+ * Output (one section per category, plain text, no JSON unless
+ * `--json` passed):
+ *  - Run summary: contract id, mode, total obligations, satisfied,
+ *    failed, wall time.
+ *  - Rollbacks: total count, breakdown by trigger
+ *    (per-obligation-falsification vs post-merge-regression),
+ *    per-obligation-type rollback count.
+ *  - Falsification: counter-examples found per adapter, with
+ *    obligation-type breakdown.
+ *  - Files touched: top 10 paths by mutation count across the run.
+ *
+ * Uses the existing `JsonlLedger` reader (no new file format). Resolves
+ * the ledger path from `<repo>/.swarm/ledger/<run-id>.jsonl` by
+ * default; `--ledger <path>` overrides.
+ */
+
+import * as path from 'path';
+import { readEntries } from '../../ledger/jsonl-ledger';
+import type { LedgerEntry } from '../../ledger/types';
+
+interface StatsFlags {
+  runId: string;
+  ledgerPath: string | null;
+  json: boolean;
+}
+
+function parseStatsFlags(argv: string[]): StatsFlags {
+  const flags: StatsFlags = {
+    runId: '',
+    ledgerPath: null,
+    json: false,
+  };
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i] ?? '';
+    if (arg === '--ledger') {
+      flags.ledgerPath = requireValue(argv, ++i, '--ledger');
+    } else if (arg === '--json') {
+      flags.json = true;
+    } else if (arg.startsWith('--')) {
+      throw new Error(`unknown flag: ${arg}`);
+    } else {
+      if (flags.runId.length > 0) throw new Error('unexpected extra positional argument');
+      flags.runId = arg;
+    }
+    i += 1;
+  }
+  if (flags.runId.length === 0) {
+    throw new Error('missing run-id: usage `swarm v8 stats <run-id> [flags]`');
+  }
+  return flags;
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  const v = argv[index];
+  if (v === undefined || v.startsWith('--')) {
+    throw new Error(`flag ${flag} requires a value`);
+  }
+  return v;
+}
+
+function formatPlain(stats: RunStats): string {
+  const lines: string[] = [];
+  lines.push(`Run: ${stats.runId}`);
+  lines.push(`  mode: ${stats.mode}`);
+  lines.push(`  obligations: ${stats.satisfied}/${stats.totalObligations} satisfied`);
+  lines.push(`  failed: ${stats.failed}`);
+  lines.push(`  wallTimeMs: ${stats.wallTimeMs}`);
+  lines.push('');
+  lines.push(`Rollbacks: ${stats.rollbackCount}`);
+  for (const [trigger, count] of Object.entries(stats.rollbackByTrigger)) {
+    lines.push(`  ${trigger}: ${count}`);
+  }
+  for (const [type, count] of Object.entries(stats.rollbackByObligationType)) {
+    lines.push(`  ${type}: ${count}`);
+  }
+  lines.push('');
+  lines.push(`Falsifications: ${stats.falsificationCount}`);
+  for (const [adapter, count] of Object.entries(stats.falsificationByAdapter)) {
+    lines.push(`  ${adapter}: ${count}`);
+  }
+  for (const [type, count] of Object.entries(stats.falsificationByObligationType)) {
+    lines.push(`  ${type}: ${count}`);
+  }
+  lines.push('');
+  lines.push('Files touched (top 10):');
+  for (const [f, count] of stats.topFiles) {
+    lines.push(`  ${f}: ${count}`);
+  }
+  return lines.join('\n');
+}
+
+interface RunStats {
+  runId: string;
+  mode: 'single' | 'tournament';
+  totalObligations: number;
+  satisfied: number;
+  failed: number;
+  wallTimeMs: number;
+  rollbackCount: number;
+  rollbackByTrigger: Record<string, number>;
+  rollbackByObligationType: Record<string, number>;
+  falsificationCount: number;
+  falsificationByAdapter: Record<string, number>;
+  falsificationByObligationType: Record<string, number>;
+  topFiles: Array<[string, number]>;
+}
+
+function computeStats(entries: LedgerEntry[], runId: string): RunStats {
+  let totalObligations = 0;
+  let satisfied = 0;
+  let failed = 0;
+  const rollbackByTrigger: Record<string, number> = {};
+  const rollbackByObligationType: Record<string, number> = {};
+  const falsificationByAdapter: Record<string, number> = {};
+  const falsificationByObligationType: Record<string, number> = {};
+  const fileTouches: Map<string, number> = new Map();
+  let rollbackCount = 0;
+  let falsificationCount = 0;
+  let firstTs: string | null = null;
+  let runFinishedTs: string | null = null;
+  let mode: 'single' | 'tournament' = 'single';
+
+  for (const e of entries) {
+    if (firstTs === null) firstTs = e.ts;
+    if (e.type === 'run-started') {
+      totalObligations = e.obligationCount;
+    } else if (e.type === 'run-finished') {
+      satisfied = e.satisfied;
+      failed = e.failed;
+      runFinishedTs = e.ts;
+    } else if (e.type === 'tournament-round-started') {
+      mode = 'tournament';
+    } else if (e.type === 'obligation-rolled-back') {
+      rollbackCount += 1;
+      rollbackByTrigger[e.trigger] = (rollbackByTrigger[e.trigger] ?? 0) + 1;
+      const obligationType = findObligationType(entries, e.obligationIndex);
+      if (obligationType) {
+        rollbackByObligationType[obligationType] =
+          (rollbackByObligationType[obligationType] ?? 0) + 1;
+      }
+    } else if (e.type === 'falsification-call') {
+      if (e.counterExamplesFound > 0) {
+        falsificationCount += 1;
+        falsificationByAdapter[e.adapterName] = (falsificationByAdapter[e.adapterName] ?? 0) + 1;
+        falsificationByObligationType[e.obligationType] =
+          (falsificationByObligationType[e.obligationType] ?? 0) + 1;
+      }
+    } else if (e.type === 'workspace-snapshot') {
+      for (const f of e.files) {
+        fileTouches.set(f.path, (fileTouches.get(f.path) ?? 0) + 1);
+      }
+    }
+  }
+
+  const wallTimeMs =
+    firstTs !== null && runFinishedTs !== null
+      ? Math.max(0, Date.parse(runFinishedTs) - Date.parse(firstTs))
+      : 0;
+
+  const topFiles = [...fileTouches.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+
+  return {
+    runId,
+    mode,
+    totalObligations,
+    satisfied,
+    failed,
+    wallTimeMs,
+    rollbackCount,
+    rollbackByTrigger,
+    rollbackByObligationType,
+    falsificationCount,
+    falsificationByAdapter,
+    falsificationByObligationType,
+    topFiles,
+  };
+}
+
+function findObligationType(entries: readonly LedgerEntry[], obligationIndex: number): string | null {
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const e = entries[i];
+    if (e && e.type === 'obligation-attempted' && e.obligationIndex === obligationIndex) {
+      return e.obligationType;
+    }
+  }
+  return null;
+}
+
+export async function handleStats(argv: string[]): Promise<number> {
+  let flags: StatsFlags;
+  try {
+    flags = parseStatsFlags(argv);
+  } catch (err) {
+    process.stderr.write(`${(err as Error).message}\n`);
+    return 1;
+  }
+
+  const ledgerPath = flags.ledgerPath ?? path.join(process.cwd(), '.swarm', 'ledger', `${flags.runId}.jsonl`);
+
+  let entries: LedgerEntry[];
+  try {
+    entries = readEntries(ledgerPath);
+  } catch (err) {
+    process.stderr.write(`failed to read ledger at ${ledgerPath}: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  const stats = computeStats(entries, flags.runId);
+
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(stats, null, 2) + '\n');
+  } else {
+    process.stdout.write(formatPlain(stats) + '\n');
+  }
+
+  return 0;
+}

--- a/src/ledger/types.ts
+++ b/src/ledger/types.ts
@@ -354,6 +354,75 @@ export interface FalsificationCallEntry extends LedgerEntryHeader {
   detail: string;
 }
 
+/**
+ * Workspace mutation snapshot recorded immediately before a producer's
+ * patch is applied. Used by `rollbackObligation` to restore the workspace
+ * when a falsifier later finds a counter-example or the post-merge
+ * integration check detects a regression.
+ *
+ * Pre-apply file bytes are written to a sidecar directory under
+ * `.swarm/snapshots/<runId>/<obligationIndex>/<preBlobSha>`; this entry
+ * carries only SHAs, not bytes, to keep the JSONL small.
+ *
+ * Content-only: blob SHAs use the same algorithm as `git hash-object`
+ * (header `blob <byteLength>\0` + content, SHA1). File modes, symlinks,
+ * and binary-special-case handling are out of scope; persona-emitted
+ * diffs in this codebase do not touch them in practice.
+ *
+ * Replay/resume treats this entry as informational. Resume drives off
+ * `obligation-satisfied` and `obligation-failed`; snapshot entries are
+ * audit trail only.
+ */
+export interface WorkspaceSnapshotEntry extends LedgerEntryHeader {
+  type: 'workspace-snapshot';
+  obligationIndex: number;
+  files: ReadonlyArray<{
+    path: string;
+    /** Pre-apply blob SHA, or 'absent' if the file did not exist. */
+    preBlobSha: string | 'absent';
+    /**
+     * Expected blob SHA after the producer's patch is applied. Used by
+     * rollback to detect cases where the file was mutated by something
+     * other than the obligation's apply (later obligation, concurrent
+     * process, manual edit) between apply and rollback.
+     */
+    expectedPostBlobSha: string | 'absent';
+  }>;
+}
+
+/**
+ * Recorded by `rollbackObligation` after the workspace files for an
+ * obligation are restored. Modeled on ARIES Compensation Log Records
+ * (Mohan et al. 1992, ACM TODS 17(1)): the entry carries enough state
+ * that a crash mid-rollback can be resumed by a future run inspecting
+ * the ledger to identify which files have already been restored.
+ *
+ * `restoredFiles` is empty when `success` is false (state-mismatch or
+ * io-error returned before any file was touched).
+ *
+ * Replay/resume treats this entry as informational; the next run sees
+ * the workspace as it actually is on disk.
+ */
+export interface ObligationRolledBackEntry extends LedgerEntryHeader {
+  type: 'obligation-rolled-back';
+  obligationIndex: number;
+  trigger: 'per-obligation-falsification' | 'post-merge-regression';
+  success: boolean;
+  restoredFiles: ReadonlyArray<{
+    path: string;
+    /**
+     * Blob SHA of the file content after rollback completed, or
+     * 'absent' if rollback unlinked the file (pre-apply state was
+     * 'absent'). This is the ARIES recovery-invariant evidence: caller
+     * verified `restoredBlobSha === preBlobSha` before writing this
+     * entry. A crash-safe resume can compare on-disk SHAs against this
+     * field to determine which restores already completed.
+     */
+    restoredBlobSha: string | 'absent';
+  }>;
+  detail: string;
+}
+
 /** Discriminated union of every ledger entry shape. */
 export type LedgerEntry =
   | RunStartedEntry
@@ -374,7 +443,9 @@ export type LedgerEntry =
   | CandidateStreamAbortedEntry
   | ObligationPreVerifiedEntry
   | PostMergeVerifiedEntry
-  | FalsificationCallEntry;
+  | FalsificationCallEntry
+  | WorkspaceSnapshotEntry
+  | ObligationRolledBackEntry;
 
 /** Type tag union for all ledger entries. */
 export type LedgerEntryType = LedgerEntry['type'];

--- a/src/population/diff-snapshot.ts
+++ b/src/population/diff-snapshot.ts
@@ -1,0 +1,138 @@
+/**
+ * Workspace snapshot primitive: record pre-apply file state before a
+ * producer's patch is applied, and compute post-apply SHAs after the
+ * applier has run.
+ *
+ * Sidecar directory rationale: inline base64 in the ledger entry would
+ * inflate JSONL size for large `file-must-exist` bodies. The sidecar
+ * keeps the ledger small and gives rollback a stable place to read
+ * original bytes from. Cleanup of the sidecar after a successful run is
+ * out of scope for this PR; a one-line note goes in the README under
+ * "Cleanup".
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ObligationV1 } from '../contract/types';
+import type { WorkspaceSnapshotEntry } from '../ledger/types';
+import { listAffectedPaths, looksLikeUnifiedDiff } from './unified-diff';
+
+/**
+ * Compute a SHA1 in the same format `git hash-object` produces, so blob
+ * SHAs in the ledger are interoperable with git tooling for debugging.
+ * Format: `blob <byteLength>\0<content>` hashed with SHA1.
+ */
+export function gitHashObject(content: Buffer): string {
+  const header = `blob ${content.length}\0`;
+  return crypto.createHash('sha1').update(header, 'utf8').update(content).digest('hex');
+}
+
+/** What the snapshot helper records before applying a patch. */
+export interface PreApplySnapshot {
+  obligationIndex: number;
+  files: ReadonlyArray<{
+    path: string;
+    preBlobSha: string | 'absent';
+  }>;
+}
+
+/**
+ * Build the sidecar directory path for a snapshot.
+ */
+function sidecarDir(repoRoot: string, runId: string, obligationIndex: number): string {
+  return path.join(repoRoot, '.swarm', 'snapshots', runId, String(obligationIndex));
+}
+
+/**
+ * Snapshot the current state of every file an obligation's response is
+ * about to mutate, and stage the pre-apply bytes to the sidecar
+ * directory. Returns null when there is nothing to snapshot:
+ *  - Response is the literal string `no-op`.
+ *  - Response is neither a unified diff nor a `file-must-exist` body.
+ *  - Diff parses to zero affected paths.
+ *
+ * The sidecar directory layout is
+ * `.swarm/snapshots/<runId>/<obligationIndex>/<preBlobSha>` containing
+ * the raw pre-apply bytes for each file. Files whose pre-apply state is
+ * 'absent' are recorded in the snapshot but no sidecar file is written
+ * for them; rollback handles 'absent' by `fs.unlink`.
+ *
+ * Idempotent: calling twice for the same (runId, obligationIndex)
+ * overwrites the sidecar directory and returns a fresh snapshot.
+ */
+export function snapshotBeforeApply(
+  repoRoot: string,
+  runId: string,
+  obligation: ObligationV1,
+  obligationIndex: number,
+  responseText: string,
+): PreApplySnapshot | null {
+  const trimmed = responseText.trim();
+  if (trimmed === 'no-op' || trimmed === '"no-op"') {
+    return null;
+  }
+
+  let affectedPaths: readonly string[];
+  if (obligation.type === 'file-must-exist') {
+    affectedPaths = [obligation.path];
+  } else if (looksLikeUnifiedDiff(trimmed)) {
+    affectedPaths = listAffectedPaths(trimmed);
+    if (affectedPaths.length === 0) {
+      return null;
+    }
+  } else {
+    return null;
+  }
+
+  const sidecar = sidecarDir(repoRoot, runId, obligationIndex);
+  if (fs.existsSync(sidecar)) {
+    fs.rmSync(sidecar, { recursive: true, force: true });
+  }
+
+  const files: Array<{ path: string; preBlobSha: string | 'absent' }> = [];
+  for (const relPath of affectedPaths) {
+    const absPath = path.join(repoRoot, relPath);
+    const exists = fs.existsSync(absPath);
+    if (!exists) {
+      files.push({ path: relPath, preBlobSha: 'absent' });
+      continue;
+    }
+    const content = fs.readFileSync(absPath);
+    const sha = gitHashObject(content);
+    files.push({ path: relPath, preBlobSha: sha });
+    const sidecarFile = path.join(sidecar, sha);
+    fs.mkdirSync(path.dirname(sidecarFile), { recursive: true });
+    fs.writeFileSync(sidecarFile, content);
+  }
+
+  if (files.length === 0) {
+    return null;
+  }
+
+  return { obligationIndex, files };
+}
+
+/**
+ * After the applier has run, hash each affected file's post-apply
+ * content and pair it with the pre-apply SHA from `pre`. The output is
+ * the `files` array for the `WorkspaceSnapshotEntry` written to the
+ * ledger. Reads from disk; never trusts `responseText` as a proxy for
+ * post-apply state, because `applyUnifiedDiff` may reject patches,
+ * normalize line endings, or skip protected paths.
+ */
+export function computePostApplyShas(
+  repoRoot: string,
+  pre: PreApplySnapshot,
+): WorkspaceSnapshotEntry['files'] {
+  return pre.files.map((f) => {
+    const absPath = path.join(repoRoot, f.path);
+    const exists = fs.existsSync(absPath);
+    const postSha = exists ? gitHashObject(fs.readFileSync(absPath)) : 'absent';
+    return {
+      path: f.path,
+      preBlobSha: f.preBlobSha,
+      expectedPostBlobSha: postSha,
+    };
+  });
+}

--- a/src/population/manager.ts
+++ b/src/population/manager.ts
@@ -14,6 +14,7 @@ import type {
   ObligationFailedEntry,
   ObligationMemoizedEntry,
   ObligationPreVerifiedEntry,
+  ObligationRolledBackEntry,
   ObligationSatisfiedEntry,
   PostMergeVerifiedEntry,
   RunFinishedEntry,
@@ -21,6 +22,7 @@ import type {
   TournamentEscalatedEntry,
   TournamentRoundStartedEntry,
   TournamentWinnerSelectedEntry,
+  WorkspaceSnapshotEntry,
 } from '../ledger/types';
 import type { AdapterRegistry } from '../falsification/adapters/registry';
 import { dispatchFalsifiers, type FalsifiersFlag } from '../falsification/dispatcher';
@@ -41,6 +43,8 @@ import {
 } from '../verification/streaming-verifier';
 import type { WasmRuntime } from '../wasm/wasm-runtime';
 import { applyFileEmit } from './diff-applier';
+import { computePostApplyShas, snapshotBeforeApply } from './diff-snapshot';
+import { rollbackObligation } from './rollback';
 import { applyUnifiedDiff, looksLikeUnifiedDiff } from './unified-diff';
 import { PopulationStateBuilder } from './state';
 import {
@@ -66,6 +70,11 @@ export interface RunPopulationOptions {
   session: Session;
   /** Ledger used to record evidence of every action. */
   ledger: JsonlLedger;
+  /**
+   * Run identifier used for snapshot sidecar directories and ledger
+   * entries. Defaults to `ledger.run()` when omitted.
+   */
+  runId?: string;
   /** Cap on commands run by the verifier. */
   commandTimeoutMs?: number;
   /** Optional cap on obligations attempted; useful for tests. */
@@ -258,6 +267,7 @@ export async function runPopulation(
 ): Promise<RunPopulationResult> {
   const start = Date.now();
   const { contract, repoRoot, registry, session, ledger, commandTimeoutMs } = options;
+  const runId = options.runId ?? ledger.run();
   const cap = options.maxObligations ?? contract.obligations.length;
   // Paths owned by file-must-exist obligations. The architect persona
   // creates these; subsequent personas (security-reviewer, verifier, etc.)
@@ -446,6 +456,7 @@ export async function runPopulation(
         memoStore,
         renderContext: tournamentRenderCtx,
         fileMustExistPaths,
+        runId,
       });
       totalUsage = addUsage(totalUsage, result.tournament.usage);
       verifierCallsSavedByMemoization += result.tournament.verifierCallsSavedByMemoization;
@@ -465,6 +476,29 @@ export async function runPopulation(
         if (falsified !== null) {
           tournamentSatisfied = false;
           tournamentDetail = falsified;
+
+          const rb = await rollbackObligation(
+            obligationIndex,
+            ledger,
+            repoRoot,
+            runId,
+            'per-obligation-falsification',
+          );
+          ledger.append<ObligationRolledBackEntry>({
+            type: 'obligation-rolled-back',
+            obligationIndex,
+            trigger: 'per-obligation-falsification',
+            success: rb.success,
+            restoredFiles: rb.restoredFiles,
+            detail: rb.success
+              ? `rolled back ${rb.restoredFiles.length} file(s) after falsification`
+              : `rollback failed: ${rb.failure?.detail ?? 'unknown'}`,
+          });
+          if (!rb.success && rb.failure?.kind !== 'no-snapshot-found') {
+            throw new Error(
+              `rollback failed for obligation ${obligationIndex}: ${rb.failure?.detail ?? 'unknown'}`,
+            );
+          }
         }
       }
       if (tournamentSatisfied) {
@@ -575,6 +609,8 @@ export async function runPopulation(
       model: responseModel,
     });
 
+    const pre = snapshotBeforeApply(repoRoot, runId, obligation, obligationIndex, responseText);
+
     if (obligation.type === 'file-must-exist') {
       applyFileEmit(repoRoot, obligation.path, responseText);
     } else if (responseText.trim() === 'no-op') {
@@ -591,6 +627,15 @@ export async function runPopulation(
       } catch {
         // The verifier will detect the failure; manager surfaces it.
       }
+    }
+
+    if (pre) {
+      const files = computePostApplyShas(repoRoot, pre);
+      ledger.append<WorkspaceSnapshotEntry>({
+        type: 'workspace-snapshot',
+        obligationIndex,
+        files,
+      });
     }
 
     const verifyOpts: Parameters<typeof verifyObligation>[1] = { repoRoot };
@@ -635,6 +680,34 @@ export async function runPopulation(
       if (falsified !== null) {
         finalSatisfied = false;
         finalDetail = falsified;
+
+        if (pre) {
+          const rb = await rollbackObligation(
+            obligationIndex,
+            ledger,
+            repoRoot,
+            runId,
+            'per-obligation-falsification',
+          );
+          ledger.append<ObligationRolledBackEntry>({
+            type: 'obligation-rolled-back',
+            obligationIndex,
+            trigger: 'per-obligation-falsification',
+            success: rb.success,
+            restoredFiles: rb.restoredFiles,
+            detail: rb.success
+              ? `rolled back ${rb.restoredFiles.length} file(s) after falsification`
+              : `rollback failed: ${rb.failure?.detail ?? 'unknown'}`,
+          });
+          if (!rb.success && rb.failure?.kind !== 'no-snapshot-found') {
+            // state-mismatch, recovery-invariant-violated, and io-error are
+            // hard failures; continuing on a corrupted workspace silently
+            // breaks subsequent obligations.
+            throw new Error(
+              `rollback failed for obligation ${obligationIndex}: ${rb.failure?.detail ?? 'unknown'}`,
+            );
+          }
+        }
       }
     }
 
@@ -710,6 +783,42 @@ export async function runPopulation(
       if (failed === 0 && regressionGap > 0) {
         failed = regressionGap;
         satisfied = Math.max(0, satisfied - regressionGap);
+      }
+
+      // Roll back ALL applied obligations in reverse order. Post-merge
+      // regression is an integration failure; obligation N may regress
+      // because obligation N+3 violated an invariant N depended on.
+      // Restoring to the pre-run state matches v6's abandon-the-bad-branch
+      // behavior and is correct without needing to identify the exact
+      // cause.
+      for (let i = outcomes.length - 1; i >= 0; i -= 1) {
+        const o = outcomes[i];
+        if (!o) continue;
+        if (!o.satisfied) continue;
+        if (o.personaId === null) continue; // pre-verified / deterministic / memoized; no snapshot exists.
+
+        const rb = await rollbackObligation(
+          o.obligationIndex,
+          ledger,
+          repoRoot,
+          runId,
+          'post-merge-regression',
+        );
+        ledger.append<ObligationRolledBackEntry>({
+          type: 'obligation-rolled-back',
+          obligationIndex: o.obligationIndex,
+          trigger: 'post-merge-regression',
+          success: rb.success,
+          restoredFiles: rb.restoredFiles,
+          detail: rb.success
+            ? `rolled back ${rb.restoredFiles.length} file(s) after post-merge regression`
+            : `rollback failed: ${rb.failure?.detail ?? 'unknown'}`,
+        });
+        if (!rb.success && rb.failure?.kind !== 'no-snapshot-found') {
+          throw new Error(
+            `post-merge rollback failed for obligation ${o.obligationIndex}: ${rb.failure?.detail ?? 'unknown'}`,
+          );
+        }
       }
     }
   }
@@ -1236,6 +1345,8 @@ interface ExecuteTournamentArgs {
    * these paths so the architect's body is preserved across persona turns.
    */
   fileMustExistPaths: ReadonlySet<string>;
+  /** Run identifier for snapshot sidecar directories. */
+  runId: string;
 }
 
 interface ExecuteTournamentResult {
@@ -1262,6 +1373,7 @@ async function executeTournament(args: ExecuteTournamentArgs): Promise<ExecuteTo
     commandTimeoutMs,
     tournamentConfig,
     memoStore,
+    runId,
   } = args;
 
   const config = {
@@ -1315,15 +1427,49 @@ async function executeTournament(args: ExecuteTournamentArgs): Promise<ExecuteTo
     config,
     renderUserMessage: (o) => renderDynamicMessage(o, repoRoot, args.renderContext),
     applyCandidate: async (candidate: TournamentCandidate, ob: ObligationV1) => {
+      const pre = snapshotBeforeApply(
+        repoRoot,
+        runId,
+        ob,
+        obligationIndex,
+        candidate.response.text,
+      );
       const applyDetail = applyTournamentCandidate(
         repoRoot,
         ob,
         candidate.response.text,
         args.fileMustExistPaths,
       );
+      if (pre) {
+        const files = computePostApplyShas(repoRoot, pre);
+        ledger.append<WorkspaceSnapshotEntry>({
+          type: 'workspace-snapshot',
+          obligationIndex,
+          files,
+        });
+      }
       const verifyOpts: Parameters<typeof verifyObligation>[1] = { repoRoot };
       if (commandTimeoutMs !== undefined) verifyOpts.commandTimeoutMs = commandTimeoutMs;
       const verifyResult = verifyObligation(ob, verifyOpts);
+      if (!verifyResult.satisfied && pre) {
+        const rb = await rollbackObligation(
+          obligationIndex,
+          ledger,
+          repoRoot,
+          runId,
+          'per-obligation-falsification',
+        );
+        ledger.append<ObligationRolledBackEntry>({
+          type: 'obligation-rolled-back',
+          obligationIndex,
+          trigger: 'per-obligation-falsification',
+          success: rb.success,
+          restoredFiles: rb.restoredFiles,
+          detail: rb.success
+            ? `rolled back ${rb.restoredFiles.length} file(s) after tournament winner failed verification`
+            : `rollback failed: ${rb.failure?.detail ?? 'unknown'}`,
+        });
+      }
       return {
         satisfied: verifyResult.satisfied,
         detail: `${applyDetail}; ${verifyResult.detail}`,

--- a/src/population/rollback.ts
+++ b/src/population/rollback.ts
@@ -1,0 +1,177 @@
+/**
+ * Workspace rollback primitive. Restore files mutated by a single
+ * obligation to their pre-apply state, modeled on the ARIES UNDO phase
+ * (Mohan et al. 1992, ACM TODS 17(1)).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { JsonlLedger } from '../ledger/jsonl-ledger';
+import type {
+  ObligationRolledBackEntry,
+  WorkspaceSnapshotEntry,
+} from '../ledger/types';
+import { gitHashObject } from './diff-snapshot';
+
+export type RollbackTrigger = ObligationRolledBackEntry['trigger'];
+
+export interface RollbackResult {
+  success: boolean;
+  restoredFiles: ReadonlyArray<{
+    path: string;
+    restoredBlobSha: string | 'absent';
+  }>;
+  /** Populated when `success` is false. */
+  failure?:
+    | { kind: 'no-snapshot-found'; detail: string }
+    | { kind: 'state-mismatch'; detail: string; offendingPath: string }
+    | { kind: 'recovery-invariant-violated'; detail: string; offendingPath: string }
+    | { kind: 'io-error'; detail: string };
+}
+
+/**
+ * Find the most recent `WorkspaceSnapshotEntry` for the given obligation
+ * index by scanning the ledger from newest to oldest.
+ */
+function findLatestSnapshot(
+  ledger: JsonlLedger,
+  obligationIndex: number,
+): WorkspaceSnapshotEntry | null {
+  const entries = ledger.readAll();
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const e = entries[i];
+    if (e && e.type === 'workspace-snapshot' && e.obligationIndex === obligationIndex) {
+      return e;
+    }
+  }
+  return null;
+}
+
+/**
+ * Restore the workspace files an obligation modified to their pre-apply
+ * state. Modeled on the ARIES UNDO phase (Mohan et al. 1992): every
+ * undo writes a Compensation Log Record (here, an
+ * `ObligationRolledBackEntry`) so a crash mid-rollback is resumable.
+ *
+ * Algorithm:
+ *  1. Find the most recent `WorkspaceSnapshotEntry` for `obligationIndex`
+ *     in the ledger. If none, return `no-snapshot-found`.
+ *  2. Idempotency check: for each file, if the current on-disk SHA
+ *     already equals `preBlobSha`, treat it as already-restored
+ *     (record `restoredBlobSha = preBlobSha` in the result, do not
+ *     rewrite). Calling rollback twice in a row is a no-op on the
+ *     second call.
+ *  3. State check: if the current on-disk SHA matches neither
+ *     `preBlobSha` (already restored) nor `expectedPostBlobSha` (the
+ *     state we expect to be undoing), return `state-mismatch` with the
+ *     offending path. The workspace was mutated between apply and
+ *     rollback by something we don't control; refusing to overwrite is
+ *     the safe move.
+ *  4. Restore: for each file whose current SHA matches
+ *     `expectedPostBlobSha`, either write the pre-apply bytes from the
+ *     sidecar directory or `fs.unlink` the file if `preBlobSha` is
+ *     'absent'. After each restore, hash the on-disk content and
+ *     verify it equals `preBlobSha`. If it doesn't, the write didn't
+ *     land as intended; return `recovery-invariant-violated` and stop.
+ *     This is the ARIES recovery invariant: at end of UNDO, file state
+ *     equals the logged before-image, verified by hash, not by
+ *     successful syscall return.
+ *  5. Return success with the per-file `restoredBlobSha` list.
+ *
+ * The caller appends the `ObligationRolledBackEntry` to the ledger
+ * after this function returns, using the returned `restoredFiles` as
+ * the entry's payload. This keeps `rollbackObligation` independent of
+ * the ledger-write side effect for testability.
+ */
+export async function rollbackObligation(
+  obligationIndex: number,
+  ledger: JsonlLedger,
+  repoRoot: string,
+  runId: string,
+  _trigger: RollbackTrigger,
+): Promise<RollbackResult> {
+  const snapshot = findLatestSnapshot(ledger, obligationIndex);
+  if (!snapshot) {
+    return {
+      success: false,
+      restoredFiles: [],
+      failure: {
+        kind: 'no-snapshot-found',
+        detail: `no workspace-snapshot entry found for obligation ${obligationIndex}`,
+      },
+    };
+  }
+
+  const sidecarRoot = path.join(repoRoot, '.swarm', 'snapshots', runId, String(obligationIndex));
+  const restoredFiles: Array<{ path: string; restoredBlobSha: string | 'absent' }> = [];
+
+  for (const f of snapshot.files) {
+    const absPath = path.join(repoRoot, f.path);
+    let currentSha: string | 'absent';
+    try {
+      currentSha = fs.existsSync(absPath) ? gitHashObject(fs.readFileSync(absPath)) : 'absent';
+    } catch (err) {
+      return {
+        success: false,
+        restoredFiles,
+        failure: {
+          kind: 'io-error',
+          detail: `failed to read current state of ${f.path}: ${(err as Error).message}`,
+        },
+      };
+    }
+
+    if (currentSha === f.preBlobSha) {
+      restoredFiles.push({ path: f.path, restoredBlobSha: f.preBlobSha });
+      continue;
+    }
+
+    if (currentSha !== f.expectedPostBlobSha) {
+      return {
+        success: false,
+        restoredFiles,
+        failure: {
+          kind: 'state-mismatch',
+          detail: `rollback for obligation ${obligationIndex} failed: file ${f.path} current SHA ${currentSha} does not match expected post-apply SHA ${f.expectedPostBlobSha}; workspace was mutated between apply and rollback`,
+          offendingPath: f.path,
+        },
+      };
+    }
+
+    try {
+      if (f.preBlobSha === 'absent') {
+        fs.unlinkSync(absPath);
+        restoredFiles.push({ path: f.path, restoredBlobSha: 'absent' });
+      } else {
+        const sidecarFile = path.join(sidecarRoot, f.preBlobSha);
+        const preBytes = fs.readFileSync(sidecarFile);
+        fs.mkdirSync(path.dirname(absPath), { recursive: true });
+        fs.writeFileSync(absPath, preBytes);
+        const afterSha = gitHashObject(fs.readFileSync(absPath));
+        if (afterSha !== f.preBlobSha) {
+          return {
+            success: false,
+            restoredFiles,
+            failure: {
+              kind: 'recovery-invariant-violated',
+              detail: `rollback for obligation ${obligationIndex} failed: file ${f.path} restored SHA ${afterSha} does not match expected pre-apply SHA ${f.preBlobSha}; write did not land as intended`,
+              offendingPath: f.path,
+            },
+          };
+        }
+        restoredFiles.push({ path: f.path, restoredBlobSha: f.preBlobSha });
+      }
+    } catch (err) {
+      return {
+        success: false,
+        restoredFiles,
+        failure: {
+          kind: 'io-error',
+          detail: `rollback for obligation ${obligationIndex} failed: ${(err as Error).message}`,
+        },
+      };
+    }
+  }
+
+  return { success: true, restoredFiles };
+}

--- a/src/population/unified-diff.ts
+++ b/src/population/unified-diff.ts
@@ -48,6 +48,16 @@ interface ParsedFilePatch {
   hunks: ParsedHunk[];
 }
 
+/** Internal representation of a parsed diff header plus its line index. */
+interface DiffHeader {
+  oldPath: string | null;
+  newPath: string | null;
+  isCreate: boolean;
+  isDelete: boolean;
+  /** 0-based line index of the `---` header in the stripped line array. */
+  headerLineIndex: number;
+}
+
 /**
  * Detect whether a response body looks like a unified diff. Used by the
  * population manager to decide between `applyFileEmit` (fenced) and
@@ -62,19 +72,25 @@ export function looksLikeUnifiedDiff(text: string): boolean {
 }
 
 /**
- * Parse a unified diff. Returns one entry per file patch. Throws when the
- * diff is structurally malformed (missing headers, hunk count mismatch,
- * unexpected leading characters).
+ * Strip optional markdown fences and split into lines.
  */
-export function parseUnifiedDiff(text: string): ParsedFilePatch[] {
+function stripAndSplit(text: string): string[] {
   const stripped = text
     .replace(/^```(?:diff|patch)?\s*\n?/i, '')
     .replace(/\n?```\s*$/i, '');
-  const lines = stripped.split('\n');
-  const patches: ParsedFilePatch[] = [];
+  return stripped.split('\n');
+}
+
+/**
+ * Parse the `---` / `+++` headers from a unified diff. Returns one entry
+ * per file patch, carrying the parsed paths and the 0-based line index of
+ * the `---` header so callers can slice the hunk body that follows.
+ * Throws when headers are malformed.
+ */
+function parseDiffHeaders(lines: readonly string[]): DiffHeader[] {
+  const headers: DiffHeader[] = [];
   let i = 0;
   while (i < lines.length) {
-    // Skip blank or noise leading lines (e.g. `diff --git`, `index ...`).
     while (i < lines.length && !lines[i]?.startsWith('--- ')) {
       i += 1;
     }
@@ -86,19 +102,94 @@ export function parseUnifiedDiff(text: string): ParsedFilePatch[] {
         `unified diff: expected '---' followed by '+++' at line ${i + 1}, got '${oldHeader}' / '${newHeader}'`,
       );
     }
-    i += 2;
     const oldRaw = oldHeader.slice(4).split('\t')[0]?.trim() ?? '';
     const newRaw = newHeader.slice(4).split('\t')[0]?.trim() ?? '';
     const isCreate = oldRaw === '/dev/null';
     const isDelete = newRaw === '/dev/null';
     const oldPath = isCreate ? null : stripPathPrefix(oldRaw);
     const newPath = isDelete ? null : stripPathPrefix(newRaw);
-    const hunks: ParsedHunk[] = [];
+    headers.push({ oldPath, newPath, isCreate, isDelete, headerLineIndex: i });
+    i += 2;
+    // Skip hunks to reach the next header.
     while (i < lines.length && lines[i]?.startsWith('@@')) {
-      const header = lines[i] ?? '';
-      const m = header.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+      i += 1;
+      while (i < lines.length) {
+        const ln = lines[i] ?? '';
+        if (ln.startsWith('@@') || ln.startsWith('--- ') || ln.startsWith('diff ')) break;
+        if (ln.length === 0 && i === lines.length - 1) {
+          i += 1;
+          break;
+        }
+        const tag = ln[0];
+        if (tag === ' ' || tag === '-' || tag === '+' || tag === '\\') {
+          i += 1;
+          continue;
+        }
+        if (tag === undefined || ln.length === 0) {
+          i += 1;
+          break;
+        }
+        i += 1;
+        break;
+      }
+    }
+  }
+  return headers;
+}
+
+/**
+ * Enumerate repo-relative file paths a unified diff targets. Used by
+ * `snapshotBeforeApply` to know which paths to hash before applying.
+ * Pure function; does not touch the filesystem.
+ *
+ * Returns an empty array when the input is not a unified diff. Caller
+ * treats empty paths as "nothing to snapshot" and skips the ledger
+ * write.
+ */
+export function listAffectedPaths(diffText: string): readonly string[] {
+  const trimmed = diffText.trim();
+  if (trimmed === 'no-op' || trimmed === '"no-op"') {
+    return [];
+  }
+  if (!looksLikeUnifiedDiff(trimmed)) {
+    return [];
+  }
+  try {
+    const lines = stripAndSplit(trimmed);
+    const headers = parseDiffHeaders(lines);
+    const paths = new Set<string>();
+    for (const h of headers) {
+      const target = h.newPath ?? h.oldPath;
+      if (target) paths.add(target);
+    }
+    return [...paths];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parse a unified diff. Returns one entry per file patch. Throws when the
+ * diff is structurally malformed (missing headers, hunk count mismatch,
+ * unexpected leading characters).
+ */
+export function parseUnifiedDiff(text: string): ParsedFilePatch[] {
+  const lines = stripAndSplit(text);
+  const headers = parseDiffHeaders(lines);
+  const patches: ParsedFilePatch[] = [];
+
+  for (let h = 0; h < headers.length; h += 1) {
+    const header = headers[h];
+    if (!header) continue;
+    const nextHeader = headers[h + 1];
+    const bodyEnd = nextHeader ? nextHeader.headerLineIndex : lines.length;
+    let i = header.headerLineIndex + 2;
+    const hunks: ParsedHunk[] = [];
+    while (i < bodyEnd && lines[i]?.startsWith('@@')) {
+      const headerLine = lines[i] ?? '';
+      const m = headerLine.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
       if (!m) {
-        throw new Error(`unified diff: malformed hunk header at line ${i + 1}: '${header}'`);
+        throw new Error(`unified diff: malformed hunk header at line ${i + 1}: '${headerLine}'`);
       }
       const oldStart = Number.parseInt(m[1] ?? '1', 10);
       const oldLines = m[2] !== undefined ? Number.parseInt(m[2], 10) : 1;
@@ -108,11 +199,11 @@ export function parseUnifiedDiff(text: string): ParsedFilePatch[] {
       const body: string[] = [];
       let oldSeen = 0;
       let newSeen = 0;
-      while (i < lines.length) {
+      while (i < bodyEnd) {
         const ln = lines[i] ?? '';
         if (ln.startsWith('@@') || ln.startsWith('--- ') || ln.startsWith('diff ')) break;
         // Tolerate trailing blank line after final hunk.
-        if (ln.length === 0 && i === lines.length - 1) {
+        if (ln.length === 0 && i === bodyEnd - 1) {
           i += 1;
           break;
         }
@@ -141,7 +232,13 @@ export function parseUnifiedDiff(text: string): ParsedFilePatch[] {
       }
       hunks.push({ oldStart, oldLines, newStart, newLines, lines: body });
     }
-    patches.push({ oldPath, newPath, isCreate, isDelete, hunks });
+    patches.push({
+      oldPath: header.oldPath,
+      newPath: header.newPath,
+      isCreate: header.isCreate,
+      isDelete: header.isDelete,
+      hunks,
+    });
   }
   return patches;
 }

--- a/test/cli/stats-handler.test.ts
+++ b/test/cli/stats-handler.test.ts
@@ -1,0 +1,238 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { JsonlLedger } from '../../src/ledger/jsonl-ledger';
+import type {
+  FalsificationCallEntry,
+  ObligationAttemptedEntry,
+  ObligationRolledBackEntry,
+  RunFinishedEntry,
+  RunStartedEntry,
+  TournamentRoundStartedEntry,
+  WorkspaceSnapshotEntry,
+} from '../../src/ledger/types';
+import { handleStats } from '../../src/cli/v8/stats-handler';
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function captureStdout<T>(fn: () => Promise<T>): Promise<{ result: T; stdout: string }> {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  (process.stdout.write as unknown) = (s: string | Uint8Array): boolean => {
+    chunks.push(typeof s === 'string' ? s : Buffer.from(s).toString('utf8'));
+    return true;
+  };
+  return fn()
+    .then((result) => ({ result, stdout: chunks.join('') }))
+    .finally(() => {
+      (process.stdout.write as unknown) = orig;
+    });
+}
+
+describe('cli/v8 stats-handler', () => {
+  it('aggregates rollback, falsification, and file-touch counts from a ledger', async () => {
+    const repo = tmpDir('v8-stats-');
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'run-stats-1');
+    ledger.append<RunStartedEntry>({
+      type: 'run-started',
+      contractId: 'c1',
+      contractHash: 'h1',
+      obligationCount: 3,
+      goal: 'g',
+    });
+    ledger.append<ObligationAttemptedEntry>({
+      type: 'obligation-attempted',
+      obligationIndex: 0,
+      obligationType: 'file-must-exist',
+      personaId: 'architect',
+    });
+    ledger.append<WorkspaceSnapshotEntry>({
+      type: 'workspace-snapshot',
+      obligationIndex: 0,
+      files: [{ path: 'a.ts', preBlobSha: 'sha1', expectedPostBlobSha: 'sha2' }],
+    });
+    ledger.append<FalsificationCallEntry>({
+      type: 'falsification-call',
+      obligationIndex: 0,
+      obligationType: 'file-must-exist',
+      adapterName: 'fake',
+      resultKind: 'counter-example-input',
+      counterExamplesFound: 1,
+      wallClockMs: 1,
+      dollarsBilled: 0,
+      dollarsApiEquivalent: 0,
+      detail: 'x',
+    });
+    ledger.append<ObligationRolledBackEntry>({
+      type: 'obligation-rolled-back',
+      obligationIndex: 0,
+      trigger: 'per-obligation-falsification',
+      success: true,
+      restoredFiles: [{ path: 'a.ts', restoredBlobSha: 'sha1' }],
+      detail: 'rolled back 1 file(s)',
+    });
+    ledger.append<ObligationAttemptedEntry>({
+      type: 'obligation-attempted',
+      obligationIndex: 1,
+      obligationType: 'build-must-pass',
+      personaId: 'implementer',
+    });
+    ledger.append<WorkspaceSnapshotEntry>({
+      type: 'workspace-snapshot',
+      obligationIndex: 1,
+      files: [{ path: 'b.ts', preBlobSha: 'sha3', expectedPostBlobSha: 'sha4' }],
+    });
+    ledger.append<ObligationRolledBackEntry>({
+      type: 'obligation-rolled-back',
+      obligationIndex: 1,
+      trigger: 'post-merge-regression',
+      success: true,
+      restoredFiles: [{ path: 'b.ts', restoredBlobSha: 'sha3' }],
+      detail: 'rolled back 1 file(s)',
+    });
+    ledger.append<RunFinishedEntry>({
+      type: 'run-finished',
+      satisfied: 1,
+      failed: 1,
+      totalUsage: {
+        inputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        outputTokens: 0,
+      },
+    });
+
+    const { result, stdout } = await captureStdout(() =>
+      handleStats(['run-stats-1', '--ledger', path.join(repo, 'ledger.jsonl'), '--json']),
+    );
+    assert.equal(result, 0);
+    const parsed = JSON.parse(stdout) as {
+      mode: string;
+      rollbackCount: number;
+      rollbackByTrigger: Record<string, number>;
+      rollbackByObligationType: Record<string, number>;
+      falsificationCount: number;
+      falsificationByAdapter: Record<string, number>;
+      falsificationByObligationType: Record<string, number>;
+      topFiles: Array<[string, number]>;
+    };
+    assert.equal(parsed.mode, 'single');
+    assert.equal(parsed.rollbackCount, 2);
+    assert.equal(parsed.rollbackByTrigger['per-obligation-falsification'], 1);
+    assert.equal(parsed.rollbackByTrigger['post-merge-regression'], 1);
+    assert.equal(parsed.rollbackByObligationType['file-must-exist'], 1);
+    assert.equal(parsed.rollbackByObligationType['build-must-pass'], 1);
+    assert.equal(parsed.falsificationCount, 1);
+    assert.equal(parsed.falsificationByAdapter['fake'], 1);
+    assert.equal(parsed.falsificationByObligationType['file-must-exist'], 1);
+    const fileNames = parsed.topFiles.map(([p]) => p).sort();
+    assert.deepEqual(fileNames, ['a.ts', 'b.ts']);
+  });
+
+  it('plain output reflects rollback counts visibly to operators', async () => {
+    const repo = tmpDir('v8-stats-');
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'run-stats-plain');
+    ledger.append<RunStartedEntry>({
+      type: 'run-started',
+      contractId: 'c1',
+      contractHash: 'h1',
+      obligationCount: 1,
+      goal: 'g',
+    });
+    ledger.append<ObligationRolledBackEntry>({
+      type: 'obligation-rolled-back',
+      obligationIndex: 0,
+      trigger: 'per-obligation-falsification',
+      success: true,
+      restoredFiles: [],
+      detail: 'r',
+    });
+    ledger.append<RunFinishedEntry>({
+      type: 'run-finished',
+      satisfied: 0,
+      failed: 1,
+      totalUsage: {
+        inputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        outputTokens: 0,
+      },
+    });
+    const { result, stdout } = await captureStdout(() =>
+      handleStats(['run-stats-plain', '--ledger', path.join(repo, 'ledger.jsonl')]),
+    );
+    assert.equal(result, 0);
+    assert.match(stdout, /Rollbacks: 1/);
+    assert.match(stdout, /per-obligation-falsification: 1/);
+  });
+
+  it('infers tournament mode from tournament-round-started entries', async () => {
+    const repo = tmpDir('v8-stats-');
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'run-stats-tourn');
+    ledger.append<RunStartedEntry>({
+      type: 'run-started',
+      contractId: 'c1',
+      contractHash: 'h1',
+      obligationCount: 1,
+      goal: 'g',
+    });
+    ledger.append<TournamentRoundStartedEntry>({
+      type: 'tournament-round-started',
+      obligationIndex: 0,
+      obligationType: 'build-must-pass',
+      roundIndex: 0,
+      roundCap: 3,
+      personaIds: ['implementer'],
+      temperatures: [0.2],
+    });
+    ledger.append<RunFinishedEntry>({
+      type: 'run-finished',
+      satisfied: 1,
+      failed: 0,
+      totalUsage: {
+        inputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        outputTokens: 0,
+      },
+    });
+    const { stdout } = await captureStdout(() =>
+      handleStats(['run-stats-tourn', '--ledger', path.join(repo, 'ledger.jsonl'), '--json']),
+    );
+    const parsed = JSON.parse(stdout) as { mode: string };
+    assert.equal(parsed.mode, 'tournament');
+  });
+
+  it('reports zero rollbacks for an empty ledger', async () => {
+    const repo = tmpDir('v8-stats-');
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'run-stats-2');
+    ledger.append<RunStartedEntry>({
+      type: 'run-started',
+      contractId: 'c2',
+      contractHash: 'h2',
+      obligationCount: 1,
+      goal: 'g',
+    });
+    ledger.append<RunFinishedEntry>({
+      type: 'run-finished',
+      satisfied: 1,
+      failed: 0,
+      totalUsage: {
+        inputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        outputTokens: 0,
+      },
+    });
+
+    const { result, stdout } = await captureStdout(() =>
+      handleStats(['run-stats-2', '--ledger', path.join(repo, 'ledger.jsonl'), '--json']),
+    );
+    assert.equal(result, 0);
+    const parsed = JSON.parse(stdout) as { rollbackCount: number };
+    assert.equal(parsed.rollbackCount, 0);
+  });
+});

--- a/test/population/diff-snapshot.test.ts
+++ b/test/population/diff-snapshot.test.ts
@@ -1,0 +1,96 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { gitHashObject, snapshotBeforeApply } from '../../src/population/diff-snapshot';
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe('population/diff-snapshot', () => {
+  it('file-must-exist against a non-existent path records preBlobSha absent', () => {
+    const repo = tmpDir('v8-snap-');
+    const obligation = { type: 'file-must-exist' as const, path: 'new-file.ts' };
+    const pre = snapshotBeforeApply(repo, 'run-1', obligation, 0, '```\nhello\n```');
+    assert.ok(pre);
+    assert.equal(pre.files.length, 1);
+    assert.equal(pre.files[0]?.path, 'new-file.ts');
+    assert.equal(pre.files[0]?.preBlobSha, 'absent');
+  });
+
+  it('file-must-exist against an existing file matches git hash-object', () => {
+    const repo = tmpDir('v8-snap-');
+    const content = 'existing content\n';
+    fs.writeFileSync(path.join(repo, 'old-file.ts'), content, 'utf8');
+    const obligation = { type: 'file-must-exist' as const, path: 'old-file.ts' };
+    const pre = snapshotBeforeApply(repo, 'run-1', obligation, 1, '```\nnew\n```');
+    assert.ok(pre);
+    assert.equal(pre.files.length, 1);
+    const gitSha = require('child_process')
+      .execSync('git hash-object --stdin', { input: content, cwd: repo })
+      .toString()
+      .trim();
+    assert.equal(pre.files[0]?.preBlobSha, gitSha);
+  });
+
+  it('unified diff touching three files enumerates all three', () => {
+    const repo = tmpDir('v8-snap-');
+    const diff = [
+      '--- a/src/a.ts',
+      '+++ b/src/a.ts',
+      '@@ -1,1 +1,2 @@',
+      ' x',
+      '+y',
+      '--- a/src/b.ts',
+      '+++ b/src/b.ts',
+      '@@ -1,1 +1,2 @@',
+      ' a',
+      '+b',
+      '--- a/src/c.ts',
+      '+++ b/src/c.ts',
+      '@@ -1,1 +1,2 @@',
+      ' p',
+      '+q',
+    ].join('\n');
+    fs.mkdirSync(path.join(repo, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(repo, 'src', 'a.ts'), 'x\n', 'utf8');
+    fs.writeFileSync(path.join(repo, 'src', 'b.ts'), 'a\n', 'utf8');
+    fs.writeFileSync(path.join(repo, 'src', 'c.ts'), 'p\n', 'utf8');
+    const obligation = { type: 'build-must-pass' as const, command: 'true' };
+    const pre = snapshotBeforeApply(repo, 'run-1', obligation, 2, diff);
+    assert.ok(pre);
+    assert.equal(pre.files.length, 3);
+    const paths = pre.files.map((f) => f.path).sort();
+    assert.deepEqual(paths, ['src/a.ts', 'src/b.ts', 'src/c.ts']);
+  });
+
+  it('response of literal no-op returns null', () => {
+    const repo = tmpDir('v8-snap-');
+    const obligation = { type: 'build-must-pass' as const, command: 'true' };
+    const pre = snapshotBeforeApply(repo, 'run-1', obligation, 0, 'no-op');
+    assert.equal(pre, null);
+  });
+
+  it('response that is neither no-op nor unified diff returns null', () => {
+    const repo = tmpDir('v8-snap-');
+    const obligation = { type: 'build-must-pass' as const, command: 'true' };
+    const pre = snapshotBeforeApply(repo, 'run-1', obligation, 0, 'just some prose');
+    assert.equal(pre, null);
+  });
+
+  it('sidecar directory contains original pre-apply bytes', () => {
+    const repo = tmpDir('v8-snap-');
+    const content = Buffer.from('binary\x00data\n');
+    fs.writeFileSync(path.join(repo, 'target.bin'), content);
+    const obligation = { type: 'file-must-exist' as const, path: 'target.bin' };
+    const pre = snapshotBeforeApply(repo, 'run-1', obligation, 3, '```\nnew\n```');
+    assert.ok(pre);
+    const sha = pre.files[0]?.preBlobSha;
+    assert.ok(sha && sha !== 'absent');
+    const sidecar = path.join(repo, '.swarm', 'snapshots', 'run-1', '3', sha);
+    assert.ok(fs.existsSync(sidecar));
+    const sidecarBytes = fs.readFileSync(sidecar);
+    assert.ok(content.equals(sidecarBytes));
+  });
+});

--- a/test/population/manager-rollback.test.ts
+++ b/test/population/manager-rollback.test.ts
@@ -1,0 +1,168 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { finalize } from '../../src/contract/compiler';
+import { JsonlLedger } from '../../src/ledger/jsonl-ledger';
+import { createDefaultRegistry } from '../../src/persona/persona-registry';
+import { runPopulation } from '../../src/population/manager';
+import { StubSession } from '../../src/session/stub-session';
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe('population/manager rollback integration', () => {
+  it('single-mode falsification path restores workspace to pre-run state', async () => {
+    const repo = tmpDir('v8-mgr-rb-');
+    const contract = finalize({
+      schemaVersion: 'v1',
+      goal: 'g',
+      repoContext: {
+        repoRoot: repo,
+        buildCommand: 'true',
+        testCommand: 'true',
+        language: 'typescript',
+      },
+      obligations: [
+        { type: 'file-must-exist', path: 'CHANGES.md' },
+        { type: 'build-must-pass', command: 'true' },
+        { type: 'test-must-pass', command: 'true' },
+      ],
+      extractor: { name: 'stub', model: null, temperature: null, promptSha256: null },
+    });
+
+    const session = new StubSession({
+      projectContext: 'CTX',
+      responder: (req) => {
+        if (req.personaId === 'architect') return '```\nhello\n```';
+        return 'no-op';
+      },
+    });
+
+    const registry = createDefaultRegistry();
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'run-rb-1');
+
+    const preState = fs.readdirSync(repo);
+
+    const fakeAdapter = {
+      name: 'fake',
+      handles: ['file-must-exist' as const, 'build-must-pass' as const, 'test-must-pass' as const],
+      falsify: async () => ({
+        result: {
+          kind: 'counter-example-input' as const,
+          obligationType: 'file-must-exist' as const,
+          inputs: [{
+            files: [],
+            reproducer: 'always fails',
+            reproducerOutput: '',
+            reproducerExitCode: 1,
+          }],
+        },
+        cost: {
+          adapterName: 'fake',
+          obligationType: 'file-must-exist',
+          wallClockMs: 1,
+          dollarsSpent: 0,
+          authMethod: 'api' as const,
+          dollarsBilled: 0,
+          dollarsTokenEstimate: 0,
+          dollarsApiEquivalent: 0,
+          counterExamplesFound: 1,
+          falsePositives: 0,
+        },
+      }),
+    };
+
+    const fakeRegistry = {
+      forObligation: () => [fakeAdapter],
+    };
+
+    const result = await runPopulation({
+      contract,
+      repoRoot: repo,
+      registry,
+      session,
+      ledger,
+      runId: 'run-rb-1',
+      falsifiers: 'on',
+      adapterRegistry: fakeRegistry as unknown as import('../../src/falsification/adapters/registry').AdapterRegistry,
+    });
+
+    assert.equal(result.failed > 0, true);
+    const entries = ledger.readAll();
+    assert.ok(entries.some((e) => e.type === 'obligation-rolled-back'));
+    const postState = fs.readdirSync(repo);
+    assert.deepEqual(postState, preState);
+  });
+
+  it('post-merge regression path restores workspace for applied obligations', async () => {
+    const repo = tmpDir('v8-mgr-pm-');
+    const contract = finalize({
+      schemaVersion: 'v1',
+      goal: 'g',
+      repoContext: {
+        repoRoot: repo,
+        buildCommand: 'true',
+        testCommand: 'true',
+        language: 'typescript',
+      },
+      obligations: [
+        { type: 'build-must-pass', command: 'test -f one.ts' },
+        { type: 'build-must-pass', command: 'test ! -f one.ts' },
+        { type: 'test-must-pass', command: 'true' },
+      ],
+      extractor: { name: 'stub', model: null, temperature: null, promptSha256: null },
+    });
+
+    const session = new StubSession({
+      projectContext: 'CTX',
+      responder: (req, callIndex) => {
+        if (req.personaId === 'implementer') {
+          if (callIndex === 0) {
+            return [
+              '--- /dev/null',
+              '+++ b/one.ts',
+              '@@ -0,0 +1,1 @@',
+              '+one',
+            ].join('\n');
+          }
+          if (callIndex === 1) {
+            return [
+              '--- a/one.ts',
+              '+++ /dev/null',
+              '@@ -1,1 +0,0 @@',
+              '-one',
+            ].join('\n');
+          }
+        }
+        return 'no-op';
+      },
+    });
+
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'run-pm-1');
+
+    const result = await runPopulation({
+      contract,
+      repoRoot: repo,
+      registry: createDefaultRegistry(),
+      session,
+      ledger,
+      runId: 'run-pm-1',
+      postMerge: true,
+    });
+
+    // Obligation 0 passes during synthesis (one.ts created), obligation 1
+    // passes during synthesis (one.ts deleted). Post-merge re-checks
+    // obligation 0: one.ts no longer exists, so it fails. This triggers
+    // rollback of all applied obligations in reverse order.
+    assert.equal(result.postMerge?.passed, false);
+    const entries = ledger.readAll();
+    assert.ok(entries.some((e) => e.type === 'obligation-rolled-back'));
+
+    // Obligation 0's rollback removes one.ts (its pre-apply state was absent).
+    // The manager rolls back every satisfied obligation, restoring the
+    // pre-run workspace state.
+    assert.equal(fs.existsSync(path.join(repo, 'one.ts')), false);
+  });
+});

--- a/test/population/rollback.test.ts
+++ b/test/population/rollback.test.ts
@@ -1,0 +1,176 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { JsonlLedger } from '../../src/ledger/jsonl-ledger';
+import type { WorkspaceSnapshotEntry } from '../../src/ledger/types';
+import { gitHashObject, snapshotBeforeApply } from '../../src/population/diff-snapshot';
+import { rollbackObligation } from '../../src/population/rollback';
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe('population/rollback', () => {
+  it('happy path: file-must-exist on absent pre-apply unlinks file', async () => {
+    const repo = tmpDir('v8-rb-');
+    const obligation = { type: 'file-must-exist' as const, path: 'created.ts' };
+    const pre = snapshotBeforeApply(repo, 'r1', obligation, 0, '```\nhello\n```');
+    assert.ok(pre);
+    fs.writeFileSync(path.join(repo, 'created.ts'), 'hello\n', 'utf8');
+    const postSha = gitHashObject(fs.readFileSync(path.join(repo, 'created.ts')));
+
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'r1');
+    ledger.append<WorkspaceSnapshotEntry>({
+      type: 'workspace-snapshot',
+      obligationIndex: 0,
+      files: [
+        { path: 'created.ts', preBlobSha: 'absent', expectedPostBlobSha: postSha },
+      ],
+    });
+
+    const rb = await rollbackObligation(0, ledger, repo, 'r1', 'per-obligation-falsification');
+    assert.equal(rb.success, true);
+    assert.equal(rb.restoredFiles.length, 1);
+    assert.equal(rb.restoredFiles[0]?.restoredBlobSha, 'absent');
+    assert.equal(fs.existsSync(path.join(repo, 'created.ts')), false);
+  });
+
+  it('happy path: existing file restored to pre-apply content', async () => {
+    const repo = tmpDir('v8-rb-');
+    const original = 'original\n';
+    fs.writeFileSync(path.join(repo, 'mutated.ts'), original, 'utf8');
+    const obligation = { type: 'file-must-exist' as const, path: 'mutated.ts' };
+    const pre = snapshotBeforeApply(repo, 'r1', obligation, 1, '```\nnew\n```');
+    assert.ok(pre);
+    fs.writeFileSync(path.join(repo, 'mutated.ts'), 'new\n', 'utf8');
+    const postSha = gitHashObject(fs.readFileSync(path.join(repo, 'mutated.ts')));
+
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'r1');
+    const files = pre.files.map((f) => ({
+      path: f.path,
+      preBlobSha: f.preBlobSha,
+      expectedPostBlobSha: postSha,
+    }));
+    ledger.append<WorkspaceSnapshotEntry>({
+      type: 'workspace-snapshot',
+      obligationIndex: 1,
+      files,
+    });
+
+    const rb = await rollbackObligation(1, ledger, repo, 'r1', 'per-obligation-falsification');
+    assert.equal(rb.success, true);
+    assert.equal(rb.restoredFiles.length, 1);
+    const restored = fs.readFileSync(path.join(repo, 'mutated.ts'), 'utf8');
+    assert.equal(restored, original);
+    assert.equal(rb.restoredFiles[0]?.restoredBlobSha, pre.files[0]?.preBlobSha);
+  });
+
+  it('recovery invariant violated: corrupt sidecar detected', async () => {
+    const repo = tmpDir('v8-rb-');
+    const original = 'original\n';
+    fs.writeFileSync(path.join(repo, 'bad.ts'), original, 'utf8');
+    const obligation = { type: 'file-must-exist' as const, path: 'bad.ts' };
+    const pre = snapshotBeforeApply(repo, 'r1', obligation, 2, '```\nnew\n```');
+    assert.ok(pre);
+    fs.writeFileSync(path.join(repo, 'bad.ts'), 'new\n', 'utf8');
+    const postSha = gitHashObject(fs.readFileSync(path.join(repo, 'bad.ts')));
+
+    // Corrupt the sidecar so rollback writes garbage.
+    const sha = pre.files[0]?.preBlobSha;
+    assert.ok(sha && sha !== 'absent');
+    const sidecar = path.join(repo, '.swarm', 'snapshots', 'r1', '2', sha);
+    fs.writeFileSync(sidecar, 'garbage\n');
+
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'r1');
+    const files = pre.files.map((f) => ({
+      path: f.path,
+      preBlobSha: f.preBlobSha,
+      expectedPostBlobSha: postSha,
+    }));
+    ledger.append<WorkspaceSnapshotEntry>({
+      type: 'workspace-snapshot',
+      obligationIndex: 2,
+      files,
+    });
+
+    const rb = await rollbackObligation(2, ledger, repo, 'r1', 'per-obligation-falsification');
+    assert.equal(rb.success, false);
+    assert.equal(rb.failure?.kind, 'recovery-invariant-violated');
+    assert.equal(rb.failure?.offendingPath, 'bad.ts');
+  });
+
+  it('state-mismatch: out-of-band mutation detected', async () => {
+    const repo = tmpDir('v8-rb-');
+    const original = 'original\n';
+    fs.writeFileSync(path.join(repo, 'stale.ts'), original, 'utf8');
+    const obligation = { type: 'file-must-exist' as const, path: 'stale.ts' };
+    const pre = snapshotBeforeApply(repo, 'r1', obligation, 3, '```\nnew\n```');
+    assert.ok(pre);
+    fs.writeFileSync(path.join(repo, 'stale.ts'), 'new\n', 'utf8');
+    const postSha = gitHashObject(fs.readFileSync(path.join(repo, 'stale.ts')));
+
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'r1');
+    const files = pre.files.map((f) => ({
+      path: f.path,
+      preBlobSha: f.preBlobSha,
+      expectedPostBlobSha: postSha,
+    }));
+    ledger.append<WorkspaceSnapshotEntry>({
+      type: 'workspace-snapshot',
+      obligationIndex: 3,
+      files,
+    });
+
+    // Mutate out-of-band.
+    fs.writeFileSync(path.join(repo, 'stale.ts'), 'tampered\n', 'utf8');
+
+    const rb = await rollbackObligation(3, ledger, repo, 'r1', 'per-obligation-falsification');
+    assert.equal(rb.success, false);
+    assert.equal(rb.failure?.kind, 'state-mismatch');
+    assert.equal(rb.failure?.offendingPath, 'stale.ts');
+    const onDisk = fs.readFileSync(path.join(repo, 'stale.ts'), 'utf8');
+    assert.equal(onDisk, 'tampered\n');
+  });
+
+  it('idempotency: second rollback is a no-op', async () => {
+    const repo = tmpDir('v8-rb-');
+    const original = 'original\n';
+    fs.writeFileSync(path.join(repo, 'idempotent.ts'), original, 'utf8');
+    const obligation = { type: 'file-must-exist' as const, path: 'idempotent.ts' };
+    const pre = snapshotBeforeApply(repo, 'r1', obligation, 4, '```\nnew\n```');
+    assert.ok(pre);
+    fs.writeFileSync(path.join(repo, 'idempotent.ts'), 'new\n', 'utf8');
+    const postSha = gitHashObject(fs.readFileSync(path.join(repo, 'idempotent.ts')));
+
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'r1');
+    const files = pre.files.map((f) => ({
+      path: f.path,
+      preBlobSha: f.preBlobSha,
+      expectedPostBlobSha: postSha,
+    }));
+    ledger.append<WorkspaceSnapshotEntry>({
+      type: 'workspace-snapshot',
+      obligationIndex: 4,
+      files,
+    });
+
+    const rb1 = await rollbackObligation(4, ledger, repo, 'r1', 'per-obligation-falsification');
+    assert.equal(rb1.success, true);
+    const rb2 = await rollbackObligation(4, ledger, repo, 'r1', 'per-obligation-falsification');
+    assert.equal(rb2.success, true);
+    assert.equal(rb2.restoredFiles[0]?.restoredBlobSha, pre.files[0]?.preBlobSha);
+    const onDisk = fs.readFileSync(path.join(repo, 'idempotent.ts'), 'utf8');
+    assert.equal(onDisk, original);
+  });
+
+  it('no-snapshot-found: returns cleanly without touching workspace', async () => {
+    const repo = tmpDir('v8-rb-');
+    fs.writeFileSync(path.join(repo, 'unchanged.ts'), 'x\n', 'utf8');
+    const ledger = new JsonlLedger(path.join(repo, 'ledger.jsonl'), 'r1');
+    const rb = await rollbackObligation(99, ledger, repo, 'r1', 'post-merge-regression');
+    assert.equal(rb.success, false);
+    assert.equal(rb.failure?.kind, 'no-snapshot-found');
+    assert.equal(fs.readFileSync(path.join(repo, 'unchanged.ts'), 'utf8'), 'x\n');
+  });
+});


### PR DESCRIPTION
## Summary

Workspace snapshot + rollback primitive for v8.0.1. Records pre-apply blob SHAs and sidecar bytes before each producer apply, then restores that state when a falsifier finds a counter-example or the post-merge integration check detects a regression. Modeled on the ARIES UNDO phase (Mohan et al. 1992); each rollback writes a compensation-log record so a crash mid-rollback is resumable.

- `rollbackObligation` enforces three invariants per file: **idempotency** (short-circuit when on-disk SHA already matches preBlobSha), **state-mismatch detection** (refuse to overwrite when on-disk SHA matches neither preBlobSha nor expectedPostBlobSha), and the **recovery invariant** (hash the on-disk content AFTER the write and verify it equals preBlobSha, surfacing `recovery-invariant-violated` rather than passing silently on a partial write).
- Wired into `population/manager.ts` at three sites: single mode, tournament mode (winner's apply, with per-candidate isolation by construction since `runTournament` only applies the top-scoring candidate per round), and post-merge regression (reverse-order rollback of every applied obligation, skipping deterministic-floor entries).
- New `swarm v8 stats <run-id>` reads the existing ledger and aggregates rollback counts by trigger and obligation type, falsification counts by adapter and obligation type, and the top 10 files by mutation count. `--json` for machine output.
- Sidecar bytes live under `.swarm/snapshots/<run-id>/<obligation-index>/<sha>`; ledger entries carry SHAs only. Cleanup is operator-driven (one-line README note).

## Test plan

- [x] `npm run build` clean
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 2153 passing; the 3 failing tests in `test/verification/test-synthesizer.test.ts` pre-exist on `main` (host-pytest layout sensitivity, unrelated to this PR)
- [x] Headline behavioral check: stub-falsifier run with `--falsifiers on` leaves `git status --porcelain` empty and `fs.readdirSync(repo)` byte-identical to pre-run (excluding `.swarm/` audit trail)
- [x] Idempotency: calling `rollbackObligation` twice in a row succeeds twice and leaves the workspace at the pre-apply bytes both times
- [x] Recovery invariant: corrupting the sidecar bytes between snapshot and rollback surfaces `recovery-invariant-violated` with the offending path
- [x] State-mismatch: out-of-band mutation between apply and rollback surfaces `state-mismatch` without overwriting the tampered file
- [x] Stats command shows rollback counts by trigger and obligation type in plain and `--json` output

## Tournament isolation note

The harness applies only the top-scoring candidate per round (`tournament.ts:449-451`); other candidates are scored on their response text and discarded. Per-candidate disk-state isolation is therefore by construction — no separate cleanup pass was needed. The manager's `applyCandidate` callback snapshots before apply, computes post-apply SHAs, and rolls back the candidate on verifier failure before the harness advances to the next round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)