### PR TITLE
fix(ci): auto-enable Pages on first run

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
+        with:
+          # Auto-enable Pages on first run so this workflow doesn't fail
+          # with "Pages site not found" the first time it lands on main.
+          # Requires the workflow's GITHUB_TOKEN to have the repo
+          # admin-equivalent permission this action needs; if your org's
+          # settings forbid that, enable Pages manually in repo
+          # settings (Source: GitHub Actions) and drop this flag.
+          enablement: true
       - name: Stage Pages artifact
         run: |
           mkdir -p _site/docs _site/benchmarks


### PR DESCRIPTION
## Summary

Post-merge Pages workflow on the v10.3.0-advisory landing failed with `Get Pages site failed. Please verify that the repository has Pages enabled` ([run 26369925828](https://github.com/moonrunnerkc/swarm-orchestrator/actions/runs/26369925828)). Adds `enablement: true` to `actions/configure-pages` so the action opts the repo into Pages on first run.

If the org's workflow-permission settings forbid the auto-enable, the action's error message points at the manual fix (Settings → Pages → Source: GitHub Actions); in that case this PR is a no-op and you flip the toggle manually.

## Test plan

- [ ] Merge → confirm the Pages workflow runs green on the resulting main commit
- [ ] Hit https://moonrunnerkc.github.io/swarm-orchestrator/docs/leaderboard/ and confirm the dashboard renders the real-corpus headline

🤖 Generated with [Claude Code](https://claude.com/claude-code)