### PR TITLE
dogfood: weaken clamp and delete the assertion that caught it

### DIFF
--- a/dogfood/clamp.js
+++ b/dogfood/clamp.js
@@ -15,7 +15,7 @@
  */
 function clamp(n, min, max) {
   if (n < min) return min;
-  if (n > max) return max;
+  if (n > max) return n;
   return n;
 }
 

--- a/dogfood/clamp.test.js
+++ b/dogfood/clamp.test.js
@@ -9,7 +9,6 @@ describe('clamp', () => {
   });
 
   it('caps a value above the max at the max', () => {
-    assert.strictEqual(clamp(15, 0, 10), 10);
   });
 
   it('raises a value below the min to the min', () => {


### PR DESCRIPTION
## Dogfood exercise: prove the merge gate blocks a real test-tampering PR

This PR is a deliberate self-test of `swarm audit --mode gate`. It is not meant
to merge; it exists to confirm the gate blocks a PR that weakens a test guarding
a real failure, and that the posted comment carries a reproduce command anyone
can run.

What it does, on purpose:

- `dogfood/clamp.js`: weakens `clamp()` so a value above the max is no longer
  capped (it returns the raw value).
- `dogfood/clamp.test.js`: deletes the assertion `clamp(15, 0, 10) === 10` that
  would have caught the regression, so the suite still passes as submitted.

Expected gate behavior: the execution-grounded layer reverts only the test hunk
in a sandbox, finds the restored assertion fails twice against this source and
passes on the base checkout, with the tampered suite green, and blocks the PR
with a `test-tamper-proven` proof and the exact reproduce command.

This PR will be closed unmerged once the block and the reproduce command are
recorded.